### PR TITLE
fix(routing): allow datachannel for Telemost locations

### DIFF
--- a/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
+++ b/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
@@ -525,7 +525,7 @@ data class LocationConfig(
 
         fun supportedTransportsForProvider(provider: String): List<String> {
             return when (normalizeProvider(provider)) {
-                PROVIDER_TELEMOST -> listOf(TRANSPORT_VP8CHANNEL, TRANSPORT_SEICHANNEL)
+                PROVIDER_TELEMOST -> listOf(TRANSPORT_DATACHANNEL, TRANSPORT_VP8CHANNEL, TRANSPORT_SEICHANNEL)
                 // The olcRTC core registers transports GLOBALLY and the auth provider is independent, so
                 // Jitsi can carry any of them — offer all three (datachannel stays the default/known-good).
                 PROVIDER_JITSI -> listOf(TRANSPORT_DATACHANNEL, TRANSPORT_VP8CHANNEL, TRANSPORT_SEICHANNEL)


### PR DESCRIPTION
## Что делает этот PR?

`LocationConfig.supportedTransportsForProvider()` для Telemost отдавал только `vp8channel`/`seichannel` — `datachannel` не было в списке, хотя мобильное ядро поддерживает его для этого провайдера так же, как и для Jitsi.

## Связанный issue

Не связано с открытым issue.

## Известная оговорка

У Telemost `datachannel` (и `seichannel`) сейчас нестабильны на уровне протокола/движка `goolom` в самом olcrtc — SCTP/сессия не всегда доходит до конца, это не связано с этим PR. Этот PR просто открывает опцию в модели/UI, соответствуя тому, что уже поддерживает ядро — саму надёжность движка он не чинит.

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально — проверено в рамках более широкой сегодняшней сессии тестирования на устройстве (этот же список транспортов использовался в собранном и установленном APK)
- [x] Проходят тесты
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве (POCO X7, Android)

## Как тестировал

Собрал и установил debug-APK на реальное устройство, подтвердил, что Telemost теперь предлагает все три транспорта в редакторе локации.