### PR TITLE
feat(core): update vendored olcrtc to 14fac07

### DIFF
--- a/olcrtc/internal/client/link.go
+++ b/olcrtc/internal/client/link.go
@@ -44,6 +44,15 @@ func (c *Client) bringUpLink(ctx context.Context, cfg Config, cancel context.Can
 	if connectErr := link.Connect(ctx); connectErr != nil {
 		return fmt.Errorf("failed to connect link: %w", connectErr)
 	}
+	// ai-generated: moved this call earlier in the function (was after the
+	// handshake block below) and added this comment explaining why.
+	// Start watching for reconnect requests now, not after the handshake
+	// below succeeds: goolom's DataChannel can close mid-handshake (its
+	// publisher-side connection is not as stable as Jitsi's), and
+	// onDataChannelClose's queueReconnect() would otherwise queue a request
+	// with nobody consuming it yet - a deadlock where the fix (reconnect)
+	// waits on the very handshake it needs to unstick.
+	c.goTracked(func() { link.WatchConnection(ctx) })
 	c.conn = muxconn.New(link, c.keys)
 	c.controlConn = muxconn.NewControl(link, c.keys)
 	pair, err := tunnelcore.NewSessionPairWithConns(
@@ -77,7 +86,6 @@ func (c *Client) bringUpLink(ctx context.Context, cfg Config, cancel context.Can
 	c.signalSessionReady()
 	c.health.RecordSession(sessionID)
 	c.startControlLoop(ctx, cfg, cancel, control)
-	c.goTracked(func() { link.WatchConnection(ctx) })
 	return nil
 }
 

--- a/olcrtc/internal/engine/goolom/signaling.go
+++ b/olcrtc/internal/engine/goolom/signaling.go
@@ -45,8 +45,12 @@ func (s *Session) sendHello() error {
 				"userAgent":      "Mozilla/5.0 (X11; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0",
 				"hwConcurrency":  runtime.NumCPU(),
 			},
-			"sdkInitializationId":    uuid.New().String(),
-			"disablePublisher":       !s.hasLocalVideoTracks(),
+			"sdkInitializationId": uuid.New().String(),
+			// ai-generated: changed condition from !s.hasLocalVideoTracks() to
+			// account for datachannel-only sessions, plus this comment.
+			// A datachannel-only session has no video track but still opens a
+			// DataChannel on the publisher PC, so it must not claim disablePublisher.
+			"disablePublisher":       !s.hasLocalVideoTracks() && s.onData == nil,
 			"disableSubscriber":      false,
 			"disableSubscriberAudio": true,
 		},

--- a/olcrtc/internal/engine/jitsi/bridge.go
+++ b/olcrtc/internal/engine/jitsi/bridge.go
@@ -140,12 +140,48 @@ func (s *Session) sendBridgeFrame(to string, data []byte) {
 	if !s.outboundFrameCurrent(data) {
 		return
 	}
-	if err := jSess.BridgeSendRaw(to, data); err != nil {
+	if err := sendEndpointRaw(jSess, to, data); err != nil {
 		if s.closed.Load() {
 			return
 		}
 		logger.Debugf("jitsi bridge send: %v", err)
 	}
+}
+
+// endpointMessage mirrors the wire shape of a Jitsi Videobridge EndpointMessage.
+// Field order matters: some Jackson versions on the bridge side drop the
+// payload field entirely if it appears before "to" (see
+// https://github.com/jitsi/jitsi-videobridge/pull/2424), so this is declared
+// and marshalled as a struct (not a map) to force colibriClass, to,
+// msgPayload in that exact order regardless of Go's map-key sorting.
+type endpointMessage struct {
+	ColibriClass string             `json:"colibriClass"`
+	To           string             `json:"to"`
+	MsgPayload   endpointRawPayload `json:"msgPayload"`
+}
+
+type endpointRawPayload struct {
+	Raw string `json:"raw"`
+}
+
+// sendEndpointRaw sends opaque bytes as msgPayload.raw instead of the
+// nonstandard top-level "raw" field used by the underlying j library's
+// BridgeSendRaw. Per the JVB EndpointMessage docs, the payload belongs under
+// msgPayload; some bridge builds silently drop the frame otherwise. See
+// olcrtc#143.
+func sendEndpointRaw(jSess *j.Session, to string, data []byte) error {
+	br := jSess.Bridge()
+	if br == nil {
+		return fmt.Errorf("bridge not open; call OpenBridge first")
+	}
+	msg := endpointMessage{
+		ColibriClass: "EndpointMessage",
+		To:           to,
+		MsgPayload: endpointRawPayload{
+			Raw: base64.StdEncoding.EncodeToString(data),
+		},
+	}
+	return br.SendJSON(msg)
 }
 
 // setJSession installs a session and republishes the readiness signal used by
@@ -288,12 +324,16 @@ func (s *Session) deliverPeerBridgePayload(from string, payload []byte) bool {
 	return true
 }
 
-// decodeRaw mirrors the j library's unexported colibri.DecodeRaw helper.
+// decodeRaw extracts the base64 payload from an EndpointMessage. It accepts
+// both the standard msgPayload.raw shape (as sent by sendEndpointRaw) and the
+// legacy top-level "raw" field (as sent by older olcrtc builds, or by peers
+// still on the j library's BridgeSendRaw), for backward compatibility. See
+// olcrtc#143.
 func decodeRaw(m j.BridgeMessage) []byte {
 	if m.Class != "EndpointMessage" {
 		return nil
 	}
-	enc, ok := m.Fields["raw"].(string)
+	enc, ok := rawFieldFrom(m.Fields)
 	if !ok {
 		return nil
 	}
@@ -302,6 +342,16 @@ func decodeRaw(m j.BridgeMessage) []byte {
 		return nil
 	}
 	return out
+}
+
+func rawFieldFrom(fields map[string]any) (string, bool) {
+	if payload, ok := fields["msgPayload"].(map[string]any); ok {
+		if raw, ok := payload["raw"].(string); ok {
+			return raw, true
+		}
+	}
+	raw, ok := fields["raw"].(string)
+	return raw, ok
 }
 
 func (s *Session) markBridgeReady() {

--- a/olcrtc/internal/engine/jitsi/jitsi_test.go
+++ b/olcrtc/internal/engine/jitsi/jitsi_test.go
@@ -2,6 +2,7 @@ package jitsi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -56,6 +57,53 @@ func TestDecodeRaw(t *testing.T) {
 	}
 	if got := decodeRaw(makeBridgeMessage(classEndpoint, map[string]any{rawFieldKey: "not-base64!!!"})); got != nil {
 		t.Fatalf("decodeRaw(bad base64) = %q, want nil", got)
+	}
+}
+
+// TestDecodeRawAcceptsMsgPayload guards olcrtc#143: sendEndpointRaw now emits
+// the payload under msgPayload.raw (the shape JVB actually documents for
+// EndpointMessage) instead of a nonstandard top-level "raw" field. decodeRaw
+// must read that shape so our own traffic round-trips.
+func TestDecodeRawAcceptsMsgPayload(t *testing.T) {
+	const payload = "hello msgPayload"
+	encoded := encodeForTest(t, []byte(payload))
+
+	got := decodeRaw(makeBridgeMessage(classEndpoint, map[string]any{
+		"msgPayload": map[string]any{rawFieldKey: encoded},
+	}))
+	if string(got) != payload {
+		t.Fatalf("decodeRaw(msgPayload.raw) = %q, want %q", got, payload)
+	}
+
+	// A msgPayload without a raw sub-field falls through to nil, not a panic.
+	if got := decodeRaw(makeBridgeMessage(classEndpoint, map[string]any{
+		"msgPayload": map[string]any{"other": "field"},
+	})); got != nil {
+		t.Fatalf("decodeRaw(msgPayload without raw) = %q, want nil", got)
+	}
+}
+
+// TestSendEndpointRawFieldOrderAndShape guards olcrtc#143: the wire JSON must
+// carry the payload as msgPayload.raw with fields declared in the order
+// colibriClass, to, msgPayload. Some Jackson versions on the bridge side drop
+// the payload if a custom field precedes "to"
+// (https://github.com/jitsi/jitsi-videobridge/pull/2424), so this is
+// asserted at the byte level, not just via a round-trip through
+// encoding/json's map-based unmarshalling which would hide a regression to
+// an unordered map[string]any payload.
+func TestSendEndpointRawFieldOrderAndShape(t *testing.T) {
+	msg := endpointMessage{
+		ColibriClass: "EndpointMessage",
+		To:           "abc123",
+		MsgPayload:   endpointRawPayload{Raw: "cGF5bG9hZA=="},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"colibriClass":"EndpointMessage","to":"abc123","msgPayload":{"raw":"cGF5bG9hZA=="}}`
+	if string(data) != want {
+		t.Fatalf("Marshal() = %s, want %s", data, want)
 	}
 }
 

--- a/olcrtc/internal/server/link.go
+++ b/olcrtc/internal/server/link.go
@@ -117,7 +117,15 @@ func (s *Server) reinstallSession(ctx context.Context, dead *smux.Session) {
 	defer s.reinstallMu.Unlock()
 	s.sessMu.RLock()
 	if s.pair != nil {
-		_ = s.pair.CloseConns()
+		// ai-generated: changed s.pair.CloseConns() to s.pair.Close() and
+		// added this comment explaining why.
+		// Close (not CloseConns): the stale pair's smux Sessions must be
+		// closed too, not just their muxconns - otherwise a recvLoop
+		// currently parked on its flow-control bucket (waiting on
+		// bucketNotify/die, not reading conn) never notices the conn died
+		// and AcceptStream on it stays blocked until something else
+		// eventually pokes it.
+		_ = s.pair.Close()
 	} else {
 		if s.conn != nil {
 			_ = s.conn.Close()

--- a/olcrtc/internal/transport/vp8channel/peers.go
+++ b/olcrtc/internal/transport/vp8channel/peers.go
@@ -99,6 +99,19 @@ type peerTable struct {
 	mu       sync.RWMutex
 	sessions map[uint32]*peerSession
 	closed   bool
+
+	// createMu serializes the get-or-create path in peerSessionFor. Frames
+	// for the same brand-new epoch can arrive on different goroutines (each
+	// RTP/track reader drives its own handleIncomingFrame loop), so two
+	// callers can both miss in get() before either has installed a session
+	// via add(). Without serializing the check-then-create sequence, both
+	// build an independent KCP runtime for the same epoch; add() just
+	// overwrites the map entry with the second one, but peerSessionFor still
+	// hands each caller its own (possibly orphaned) session object. That
+	// silently splits one peer's reliable byte stream across two unrelated
+	// KCP state machines, which reassemble garbage that fails AEAD
+	// authentication one layer up in muxconn - see olcrtc#142.
+	createMu sync.Mutex
 }
 
 // get returns the session for epoch, refreshing its idle timer.
@@ -115,13 +128,23 @@ func (t *peerTable) get(epoch uint32) *peerSession {
 }
 
 // add installs a freshly created session, evicting the oldest peer when the
-// table is full. It returns false when the table is already closed, in which
-// case the caller must release the session it built.
+// table is full. It returns false when the table is already closed or a
+// session for this epoch is already installed, in which case the caller must
+// release the session it built instead of using it. The latter should never
+// happen in practice - peerSessionFor serializes creation via createMu - but
+// refusing a silent overwrite here is a cheap backstop: without it, a second
+// session for the same epoch would clobber the map entry while some other
+// caller keeps using the orphaned first one, splitting that peer's KCP
+// stream across two state machines. See olcrtc#142.
 func (t *peerTable) add(sess *peerSession) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if t.closed {
+		return false
+	}
+
+	if _, exists := t.sessions[sess.epoch]; exists {
 		return false
 	}
 
@@ -222,7 +245,20 @@ func parsePeerID(peerID string) (uint32, error) {
 // peerSessionFor returns the session for epoch, creating it on demand. It
 // returns nil when the KCP session cannot be started or the transport is
 // shutting down.
+//
+// The whole check-then-create sequence is serialized by peers.createMu so
+// concurrent first-contact frames for the same new epoch (arriving on
+// different reader goroutines) always converge on exactly one session
+// instead of racing to install two independent KCP runtimes for it. See
+// olcrtc#142.
 func (p *streamTransport) peerSessionFor(epoch uint32) *peerSession {
+	if sess := p.peers.get(epoch); sess != nil {
+		return sess
+	}
+
+	p.peers.createMu.Lock()
+	defer p.peers.createMu.Unlock()
+
 	if sess := p.peers.get(epoch); sess != nil {
 		return sess
 	}

--- a/olcrtc/internal/transport/vp8channel/transport_unit_test.go
+++ b/olcrtc/internal/transport/vp8channel/transport_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -751,6 +752,66 @@ func TestReorderBufferReusesPacketStorage(t *testing.T) {
 			t.Fatalf("second payload = %q", packet.Payload)
 		}
 	})
+}
+
+// TestPeerSessionForConcurrentFirstContactConverges guards olcrtc#142: two
+// goroutines racing to create the session for a brand-new peer epoch (which
+// happens for real when independent RTP reader goroutines deliver that
+// peer's first data and control frames back to back) must converge on
+// exactly one *peerSession instead of each minting its own KCP runtime and
+// clobbering the other in the table.
+func TestPeerSessionForConcurrentFirstContactConverges(t *testing.T) {
+	tr := &streamTransport{
+		stream:        &fakeVideoStream{canSend: true},
+		closeCh:       make(chan struct{}),
+		writerDone:    make(chan struct{}),
+		bindingToken:  bindingToken("room-142"),
+		localEpoch:    0x100,
+		serverMode:    true,
+		frameInterval: time.Millisecond,
+		onPeerData:    func(string, []byte) {},
+	}
+	defer func() {
+		close(tr.closeCh)
+		tr.peers.closeAll()
+	}()
+
+	const goroutines = 32
+	const epoch = 0x9a301844
+
+	results := make(chan *peerSession, goroutines)
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	for range goroutines {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			results <- tr.peerSessionFor(epoch)
+		}()
+	}
+	start.Done()
+	done.Wait()
+	close(results)
+
+	var first *peerSession
+	for sess := range results {
+		if sess == nil {
+			t.Fatal("peerSessionFor returned nil under contention")
+		}
+		if first == nil {
+			first = sess
+			continue
+		}
+		if sess != first {
+			t.Fatalf("peerSessionFor returned distinct sessions for the same epoch: %p != %p", sess, first)
+		}
+	}
+
+	if got := tr.peers.len(); got != 1 {
+		t.Fatalf("peer table has %d sessions for one epoch, want 1", got)
+	}
 }
 
 func TestSeqLessWrapAround(t *testing.T) {


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

Точечно обновляет вендоренный `olcrtc` с `f616f57` (после #28) до актуального `14fac07` — подтягивает два коммита апстрима: наш собственный `fix(goolom): stop datachannel sessions deadlocking on mid-handshake drops` (смержен сегодня, PR openlibrecommunity/olcrtc#144) и `fix(jitsi): send EndpointMessage payload as msgPayload.raw` мейнтейнера. Никаких breaking-изменений API между этими коммитами нет, поэтому обновление точечное — скопированы только 7 реально изменившихся файлов, а не всё дерево `olcrtc/` целиком.

Локальные наработки YPtun (`mobile/mobile_rooms.go`, `internal/bond/`) не трогал — эти коммиты их не касаются.

## Связанный issue

нет

## Тип изменения

- [x] 🧹 Рефакторинг / чистка

## Чеклист

- [x] Ответвление от `Beta`
- [ ] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`go build ./... && go vet ./... && go test ./...` внутри `olcrtc/`, плюс отдельно `mobile/`)
- [x] Изменение сфокусировано на одном
- [ ] Проверено на устройстве/эмуляторе

## Как тестировал

Только Go-слой (`olcrtc/`) — `go build`/`go vet`/`go test` по изменённым пакетам и по `mobile/` целиком, всё зелёное. Полную Android-сборку и живой тест на устройстве не гонял — изменение чисто в вендоренном Go-коде, публичный `mobile`-мост не тронут, поведение Kotlin-стороны не меняется.
