### PR TITLE
fix(desktop): Linux TUN left hev-socks5-tunnel and olcRTC running as root after every disconnect

### DIFF
--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -785,7 +785,7 @@ class DesktopVpnManager private constructor(
             runCatching { engineController.stopAll() }
             runCatching { org.olcbox.app.vpn.desktop.YpTunCore.bindOutboundInterface(0) }
             engineLocation = null
-            stopProcess(process)
+            stopProcess(process, privileged = (activeDesktopMode ?: DesktopMode.current()) == DesktopMode.LinuxTun)
             process = null
             deleteOlcRtcConfig()
 
@@ -1008,7 +1008,8 @@ class DesktopVpnManager private constructor(
 
         setStatus(VpnStatus.Stopping)
 
-        when (activeDesktopMode ?: DesktopMode.current()) {
+        val stoppingDesktopMode = activeDesktopMode ?: DesktopMode.current()
+        when (stoppingDesktopMode) {
             DesktopMode.LinuxTun -> {
                 runCatching {
                     linuxTunController.stop(tunProcess)
@@ -1045,7 +1046,7 @@ class DesktopVpnManager private constructor(
         runCatching { org.olcbox.app.vpn.desktop.YpTunCore.bindOutboundInterface(0) }
         engineLocation = null
 
-        stopProcess(process)
+        stopProcess(process, privileged = stoppingDesktopMode == DesktopMode.LinuxTun)
         process = null
         deleteOlcRtcConfig()
 
@@ -1244,7 +1245,7 @@ class DesktopVpnManager private constructor(
         }.isSuccess
     }
 
-    private fun stopProcess(target: Process?) {
+    private suspend fun stopProcess(target: Process?, privileged: Boolean = false) {
         if (target == null) return
         if (!target.isAlive) return
 
@@ -1261,6 +1262,23 @@ class DesktopVpnManager private constructor(
 
             target.destroyForcibly()
             target.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+
+        // A pkexec-elevated olcRTC now runs as root, and this JVM does not: destroy()/destroyForcibly()
+        // above call kill() as our own uid, which cannot signal a process owned by a different, more
+        // privileged one - even one we originally spawned. Confirmed live (2026-08-29): a plain `kill`
+        // on such a pid fails with EPERM, and the process survives every disconnect untouched, then goes
+        // on to fool the NEXT connect's canConnectToSocks() readiness check into firing early. Escalate.
+        if (privileged && target.isAlive) {
+            val pid = target.pid()
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val killProcess = ProcessBuilder(LinuxPrivilege.command(listOf("kill", pid.toString())))
+                        .redirectErrorStream(true)
+                        .start()
+                    killProcess.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                }
+            }
         }
     }
 

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
@@ -14,6 +14,7 @@ internal class LinuxTunController(
     private val addLog: (String) -> Unit
 ) {
     private var routesInstalled = false
+    private var hevBinary: Path? = null
 
     suspend fun start(
         hevBinary: Path,
@@ -21,6 +22,7 @@ internal class LinuxTunController(
         socksUsername: String = "",
         socksPassword: String = ""
     ): Process {
+        this.hevBinary = hevBinary
         val upScript = writeUpScript()
         val downScript = writeDownScript()
         val config = writeConfig(socksPort, upScript, downScript, socksUsername, socksPassword)
@@ -109,6 +111,15 @@ internal class LinuxTunController(
         error("$TUN_NAME routes were not installed")
     }
 
+    private suspend fun processMatchingBinaryExists(binary: Path): Boolean = withContext(Dispatchers.IO) {
+        runCatching {
+            val process = ProcessBuilder("pgrep", "-f", binary.toString())
+                .redirectErrorStream(true)
+                .start()
+            process.waitFor(1, TimeUnit.SECONDS) && process.exitValue() == 0
+        }.getOrDefault(false)
+    }
+
     private suspend fun interfaceExists(): Boolean = withContext(Dispatchers.IO) {
         runCatching {
             val process = ProcessBuilder("ip", "link", "show", TUN_NAME)
@@ -167,14 +178,28 @@ internal class LinuxTunController(
             .start()
     }
 
-    private fun stopProcess(process: Process?) {
-        if (process == null || !process.isAlive) return
-        process.toHandle().descendants().forEach { it.destroy() }
-        process.destroy()
-        if (!process.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-            process.toHandle().descendants().forEach { it.destroyForcibly() }
-            process.destroyForcibly()
-            process.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    private suspend fun stopProcess(process: Process?) {
+        if (process != null && process.isAlive) {
+            process.toHandle().descendants().forEach { it.destroy() }
+            process.destroy()
+            if (!process.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                process.toHandle().descendants().forEach { it.destroyForcibly() }
+                process.destroyForcibly()
+                process.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            }
+        }
+        // hev-socks5-tunnel daemonizes itself (double-forks and detaches), so by the time we get here
+        // the Process handle above is often already !isAlive and the block does nothing - the real
+        // privileged process has been reparented to init, still holding the TUN device open. Check
+        // unprivileged first (pgrep reads another user's /proc/*/cmdline fine, no root needed) and only
+        // escalate to a pkexec kill when something is actually still there - stop() runs on every
+        // disconnect AND on every failed connect attempt's cleanup (sometimes twice), so an unconditional
+        // pkexec call here would prompt for a second, unrelated authorization on the common path where
+        // there is nothing left to clean up.
+        hevBinary?.let { binary ->
+            if (processMatchingBinaryExists(binary)) {
+                runCatching { runPrivilegedCommand(listOf("pkill", "-f", binary.toString())) }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

Чинит две связанные утечки процессов в Linux TUN-режиме — обе оставляли root-процессы висеть после disconnect, и вторая из них порождала гонку на повторном подключении:

- **`hev-socks5-tunnel` не убивался.** Он сам демонизируется (двойной fork), поэтому исходный `Process`-хендл в `LinuxTunController.stopProcess()` быстро становится `!isAlive`, и метод молча выходил, ничего не убивая — реальный root-процесс и TUN-интерфейс `olcbox0` оставались висеть навсегда. Фикс: привилегированный `pkexec pkill -f <путь-к-бинарнику>` как fallback — но только после непривилегированной проверки через `pgrep` (иначе на каждый disconnect всплывал бы лишний, несвязанный запрос авторизации даже когда чистить нечего).
- **`olcrtc-linux-amd64` (тоже поднятый через pkexec) тоже не убивался** — но по другой причине: `DesktopVpnManager.stopProcess()` зовёт обычный `Process.destroy()`/`destroyForcibly()`, который шлёт `kill()` от имени обычного юзера — а процесс к этому моменту уже принадлежит root. Обычный `kill` не может сигналить чужому (более привилегированному) uid, даже своему бывшему прямому child-процессу — подтверждено живьём (`Операция не позволена` / EPERM). Фикс: если процесс запускался privileged, эскалируем до `pkexec kill <pid>`.
- Второй баг был не просто "мусорный процесс" — он ломал следующее подключение: `waitForOlcRtcReady()` считает olcRTC готовым, если `canConnectToSocks(socksPort)` — а порт фиксированный, и **старый** живой процесс с прошлой сессии на нём и отвечал, из-за чего проверка проходила мгновенно, не дожидаясь, пока **новый**, только что запущенный через pkexec olcRTC пройдёт свою собственную авторизацию. В итоге запускался `hev-socks5-tunnel` со своим отдельным pkexec-запросом, пока предыдущий (olcRTC) ещё висел неавторизованным — оба запроса сталкивались в polkit-агенте с ошибкой "Another client is already authenticating", и диалог с паролем пропадал прямо во время ввода.

## Связанный issue

нет

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`./gradlew :sharedUI:jvmTest`)
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве/эмуляторе (опиши ниже)

## Как тестировал

Оба файла — `jvmMain` (десктоп-специфичный source set), Android не затрагивают. Именно `:androidApp:assembleDebug` не гонял (нет смысла — изменение туда не попадает), но локальная сборка проверена другой командой того же уровня — `:desktopApp:packageReleaseLinuxAppImage` (компилирует тот же самый jvmMain-код) — `BUILD SUCCESSFUL`, плюс живой запуск и тест собранного AppImage ниже.

Живой тест на реальном ПК (CachyOS/Arch, Niri), два подряд полных цикла подключения/отключения через собранный `.deb`+AppImage:

```
18:49:32 connected → 18:51:23 stopped
18:51:31 start → 18:51:51 connected → 18:52:23 stopped
```

Оба цикла — без единой ошибки авторизации. После каждого disconnect (проверено `ps`/`ip -br link show`) — ни `hev-socks5-tunnel`, ни `olcrtc-linux-amd64`, ни интерфейс `olcbox0` не остаются. До фикса тот же сценарий воспроизводил зависание обоих процессов после первого же disconnect и (на повторном подключении) гонку двух pkexec-авторизаций — подтверждено логами `journalctl --user` (`pkexec[...]: ... Not authorized`, `polkit-kde-authentication-agent-1: Another client is already authenticating`) и живой проверкой прав через `kill -TERM <pid>` от обычного юзера (`Операция не позволена`).