### PR TITLE
fix(desktop): tiling window managers absorbed the fixed-size window into a tile

### DIFF
--- a/YPtun/desktopApp/src/main/kotlin/main.kt
+++ b/YPtun/desktopApp/src/main/kotlin/main.kt
@@ -640,6 +640,10 @@ private fun runApp(args: Array<String>) = application {
         icon = painterResource("LinuxIcon.png"),
         visible = isWindowVisible,
         state = windowState,
+        // Tiling window managers (niri, Sway, Hyprland) commonly key their auto-float heuristic off
+        // this flag — without it the app's fixed-size window gets tiled into whatever slot is next,
+        // instead of floating at its intended size.
+        resizable = false,
         onCloseRequest = {
             isWindowVisible = false
         },


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

Главному окну (`title = "YPtun"`) не хватало `resizable = false`. На тайлинговых Wayland-компоузерах (niri, Sway, Hyprland) именно этот флаг обычно определяет, будет ли окно плавающим — без него окно фиксированного размера принудительно затягивало в тайл вместо floating-режима, в котором оно и задумано (430×780).

## Связанный issue

нет

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`./gradlew :sharedUI:jvmTest`)
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве/эмуляторе (опиши ниже)

## Как тестировал

Изменение чисто десктопное (`desktopApp/src/main/kotlin/main.kt`), Android не затрагивает. `:androidApp:assembleDebug` не гонял — локальная сборка проверена другой командой того же уровня, `:desktopApp:packageReleaseLinuxAppImage` (компилирует тот же самый код), `BUILD SUCCESSFUL`. `jvmTest` зелёный.

Живой тест на реальном ПК (CachyOS/Arch, Niri): собранный AppImage запущен, окно строго плавающее — не тайлится, можно свободно перемещать, размер держится фиксированным как задумано.