### PR TITLE
fix(desktop): one pkexec instead of two/three per Linux TUN connect/disconnect

### DIFF
--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -37,6 +37,7 @@ import org.olcbox.app.vpn.desktop.LinuxTunController
 import org.olcbox.app.vpn.desktop.OlcRtcCommand
 import org.olcbox.app.vpn.desktop.PacServer
 import org.olcbox.app.vpn.desktop.WindowsTunController
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.nio.charset.StandardCharsets
@@ -715,12 +716,7 @@ class DesktopVpnManager private constructor(
             }
 
             when (desktopMode) {
-                DesktopMode.LinuxTun -> startLinuxTun(
-                    socksPort = bridgeSettings.port,
-                    requestGeneration = requestGeneration,
-                    socksUsername = bridgeSettings.username,
-                    socksPassword = bridgeSettings.password
-                )
+                DesktopMode.LinuxTun -> startLinuxTun(requestGeneration = requestGeneration)
                 DesktopMode.WindowsTun -> if (engineController.tunHandledInCore) {
                     // sing-box raised the wintun adapter itself (per-process split tunneling);
                     // no external tun2socks needed.
@@ -754,12 +750,9 @@ class DesktopVpnManager private constructor(
             }
 
             when (activeDesktopMode ?: DesktopMode.current()) {
+                // Cleanup (hev + routes, bundled with olcRTC's own kill into one pkexec call) happens
+                // below via stopProcess(process, privileged = ...) — see LinuxTunController.onStopped.
                 DesktopMode.LinuxTun -> {
-                    runCatching {
-                        linuxTunController.stop(tunProcess)
-                    }.onFailure {
-                        addLog("Linux TUN cleanup failed: ${it.message}")
-                    }
                     tunProcess = null
                 }
                 DesktopMode.WindowsTun -> {
@@ -837,20 +830,19 @@ class DesktopVpnManager private constructor(
         }
     }
 
-    private suspend fun startLinuxTun(
-        socksPort: Int,
-        requestGeneration: Long,
-        socksUsername: String = "",
-        socksPassword: String = ""
-    ) {
-        val hevBinary = DesktopNativeAssets.resolveHevSocks5TunnelBinary()
-        tunProcess = linuxTunController.start(hevBinary, socksPort, socksUsername, socksPassword)
+    /**
+     * hev itself was already launched — backgrounded inside the SAME combined pkexec call that
+     * started olcRTC (see startOlcRtcProcess/writeLinuxTunLaunchScript) — so all that's left here is
+     * waiting for its up-script to actually install the TUN interface + route. [tunProcess] stays
+     * null in this mode: there is no separate Process handle for hev, its output already rides
+     * olcRTC's own (tagged "tun: ", split out in the reader loop there).
+     */
+    private suspend fun startLinuxTun(requestGeneration: Long) {
+        linuxTunController.awaitReady()
 
         if (requestGeneration != generation) {
             throw CancellationException("Desktop start superseded")
         }
-
-        startTunLogReader(tunProcess ?: error("hev-socks5-tunnel process is missing"))
     }
 
     private suspend fun startWindowsTun(
@@ -1010,12 +1002,9 @@ class DesktopVpnManager private constructor(
 
         val stoppingDesktopMode = activeDesktopMode ?: DesktopMode.current()
         when (stoppingDesktopMode) {
+            // Cleanup (hev + routes, bundled with olcRTC's own kill into one pkexec call) happens
+            // below via stopProcess(process, privileged = ...) — see LinuxTunController.onStopped.
             DesktopMode.LinuxTun -> {
-                runCatching {
-                    linuxTunController.stop(tunProcess)
-                }.onFailure {
-                    addLog("Linux TUN stop failed: ${it.message}")
-                }
                 tunProcess = null
             }
             DesktopMode.WindowsTun -> {
@@ -1094,17 +1083,29 @@ class DesktopVpnManager private constructor(
             dataDir = dataDir
         )
         val configPath = writeOlcRtcClientConfig(olcRtcCommand)
-        val command = olcRtcCommand.args(configPath)
+        val olcRtcCommandArgs = olcRtcCommand.args(configPath)
 
         addLog("Starting olcRTC provider=$provider, transport=${config.transport}, room=${config.id}, port=${socksSettings.port}")
 
-        if (privileged) {
-            addLog("Linux TUN mode starts olcRTC with elevated privileges to bypass the TUN route")
+        // Linux TUN mode needs hev-socks5-tunnel running as root too (to bypass its own TUN route) —
+        // launched together under this SAME pkexec authorization instead of its own separate one (see
+        // writeLinuxTunLaunchScript). hev's own output rides the same pipe, tagged, and gets split back
+        // out in the reader loop below — there's no separate Process handle for it to read from, since
+        // the wrapper script (not this JVM) is what actually spawns it.
+        val command = if (privileged) {
+            addLog("Linux TUN mode starts olcRTC and hev-socks5-tunnel together under one elevated authorization")
+            val hevCommand = linuxTunController.prepareHevLaunch(
+                hevBinary = DesktopNativeAssets.resolveHevSocks5TunnelBinary(),
+                socksPort = socksSettings.port,
+                socksUsername = socksSettings.username,
+                socksPassword = socksSettings.password
+            )
+            LinuxPrivilege.command(listOf("sh", writeLinuxTunLaunchScript(hevCommand, olcRtcCommandArgs).toString()))
+        } else {
+            olcRtcCommandArgs
         }
 
-        val processBuilder = ProcessBuilder(
-            if (privileged) LinuxPrivilege.command(command) else command
-        ).redirectErrorStream(true)
+        val processBuilder = ProcessBuilder(command).redirectErrorStream(true)
 
         processBuilder.environment()["NO_PROXY"] = "127.0.0.1,localhost"
         processBuilder.environment()["no_proxy"] = "127.0.0.1,localhost"
@@ -1120,22 +1121,39 @@ class DesktopVpnManager private constructor(
         }
 
         val readerJob = scope.launch {
-            startedProcess.inputStream.bufferedReader().useLines { lines ->
-                lines.forEach { line ->
-                    if (!isActive) return@forEach
+            try {
+                startedProcess.inputStream.bufferedReader().useLines { lines ->
+                    lines.forEach { line ->
+                        if (!isActive) return@forEach
 
-                    if (logOutput) {
-                        addLog("rtc: $line")
-                    }
+                        // hev-socks5-tunnel's tagged lines (see writeLinuxTunLaunchScript) — a
+                        // different process, so none of olcRTC's own readiness/fatal-line checks
+                        // below apply to them.
+                        if (line.startsWith(HEV_LOG_PREFIX)) {
+                            if (logOutput) addLog("tun: ${line.removePrefix(HEV_LOG_PREFIX)}")
+                            return@forEach
+                        }
 
-                    if (line.contains("SOCKS5 server listening", ignoreCase = true)) {
-                        ready.complete(Unit)
-                    }
+                        if (logOutput) {
+                            addLog("rtc: $line")
+                        }
 
-                    if (isFatalOlcRtcStartupLine(line)) {
-                        startupFailure.complete(line)
+                        if (line.contains("SOCKS5 server listening", ignoreCase = true)) {
+                            ready.complete(Unit)
+                        }
+
+                        if (isFatalOlcRtcStartupLine(line)) {
+                            startupFailure.complete(line)
+                        }
                     }
                 }
+            } catch (e: IOException) {
+                // stopProcess()'s target.destroy()/destroyForcibly() closes this stream to unblock a
+                // readLine() parked waiting for more output — a plain synchronous blocking call, the
+                // only way to interrupt it. Expected on every normal disconnect, not a failure — but
+                // matched on the exact message so any OTHER IOException (a genuine read failure) still
+                // surfaces instead of being silently swallowed here too.
+                if (e.message != "Stream closed") throw e
             }
         }
 
@@ -1146,6 +1164,35 @@ class DesktopVpnManager private constructor(
 
         return startedProcess
     }
+
+    /**
+     * Backgrounds hev, tags its output, then execs into olcRTC — same pid throughout (pkexec itself
+     * already execs rather than forking; this just adds one more hop), so every existing PID-based
+     * lifecycle assumption downstream (isAlive/waitFor/pid() in stopProcess) keeps working unchanged.
+     * hev double-forks and detaches on its own regardless of what happens to this wrapper afterward,
+     * so it survives the exec with no `disown`/`nohup` needed.
+     */
+    private fun writeLinuxTunLaunchScript(hevCommand: List<String>, olcRtcCommand: List<String>): Path {
+        val runtimeDir = DesktopPaths.appDataDir().resolve("runtime")
+        Files.createDirectories(runtimeDir)
+        val script = runtimeDir.resolve("linux-tun-launch.sh")
+        Files.writeString(
+            script,
+            buildString {
+                appendLine("#!/bin/sh")
+                append(shellQuotedCommand(hevCommand))
+                appendLine(" 2>&1 | sed -u 's/^/$HEV_LOG_PREFIX/' &")
+                append("exec ")
+                appendLine(shellQuotedCommand(olcRtcCommand))
+            }
+        )
+        script.toFile().setExecutable(true, true)
+        return script
+    }
+
+    /** POSIX single-quoted: the only escape inside is closing the quote, inserting a literal ', reopening. */
+    private fun shellQuotedCommand(command: List<String>): String =
+        command.joinToString(" ") { "'" + it.replace("'", "'\\''") + "'" }
 
     private fun writeOlcRtcClientConfig(command: OlcRtcCommand): Path {
         val runtimeDir = DesktopPaths.appDataDir().resolve("runtime")
@@ -1246,22 +1293,21 @@ class DesktopVpnManager private constructor(
     }
 
     private suspend fun stopProcess(target: Process?, privileged: Boolean = false) {
-        if (target == null) return
-        if (!target.isAlive) return
-
-        target.toHandle().descendants().forEach {
-            it.destroy()
-        }
-
-        target.destroy()
-
-        if (!target.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        if (target != null && target.isAlive) {
             target.toHandle().descendants().forEach {
-                it.destroyForcibly()
+                it.destroy()
             }
 
-            target.destroyForcibly()
-            target.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            target.destroy()
+
+            if (!target.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                target.toHandle().descendants().forEach {
+                    it.destroyForcibly()
+                }
+
+                target.destroyForcibly()
+                target.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            }
         }
 
         // A pkexec-elevated olcRTC now runs as root, and this JVM does not: destroy()/destroyForcibly()
@@ -1269,26 +1315,57 @@ class DesktopVpnManager private constructor(
         // privileged one - even one we originally spawned. Confirmed live (2026-08-29): a plain `kill`
         // on such a pid fails with EPERM, and the process survives every disconnect untouched, then goes
         // on to fool the NEXT connect's canConnectToSocks() readiness check into firing early. Escalate.
-        // Ждём смерти САМОГО процесса, а не команды kill, и добиваем -KILL: иначе stopProcess вернётся,
-        // пока olcRTC ещё разбирает SIGTERM (или игнорирует его), фиксированный SOCKS-порт останется
-        // занятым - и следующий connect снова пройдёт canConnectToSocks() мгновенно, ровно тот баг,
-        // который этот фикс и закрывает.
-        if (privileged && target.isAlive) {
-            val pid = target.pid()
+        //
+        // hev-socks5-tunnel needs the exact same treatment (see LinuxTunController.privilegedCleanupCommands)
+        // — it double-forks at its own startup, so by now there is no Process handle for it here either,
+        // privileged or not. Both are ALWAYS true on a Linux TUN disconnect, not rare fallbacks, so this
+        // whole block bundles olcRTC's kill AND hev/route cleanup into ONE pkexec-authorized script
+        // instead of prompting for authorization once per process.
+        if (privileged) {
             withContext(Dispatchers.IO) {
-                for (signal in listOf("-TERM", "-KILL")) {
-                    runCatching {
-                        ProcessBuilder(LinuxPrivilege.command(listOf("kill", signal, pid.toString())))
-                            .redirectErrorStream(true)
-                            .start()
-                            .waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                    }
-                    // waitpid по своему ребёнку работает и когда тот стал root'ом.
-                    if (target.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) return@withContext
+                val pid = target?.takeIf { it.isAlive }?.pid()
+                val script = buildString {
+                    if (pid != null) appendLine(killWithEscalationScript(pid))
+                    linuxTunController.privilegedCleanupCommands().forEach { appendLine(it) }
                 }
-                addLog("Failed to stop the elevated olcRTC process (pid $pid)")
+                val runtimeDir = DesktopPaths.appDataDir().resolve("runtime")
+                Files.createDirectories(runtimeDir)
+                val scriptFile = Files.createTempFile(runtimeDir, "linux-tun-stop-", ".sh")
+                runCatching {
+                    Files.writeString(scriptFile, script)
+                    ProcessBuilder(LinuxPrivilege.command(listOf("sh", scriptFile.toString())))
+                        .redirectErrorStream(true)
+                        .start()
+                        .waitFor(PROCESS_STOP_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS)
+                    if (pid != null && target.isAlive) {
+                        addLog("Failed to stop the elevated olcRTC process (pid $pid)")
+                    }
+                }.onFailure {
+                    addLog("Failed to stop the elevated Linux TUN processes: ${it.message}")
+                }
+                runCatching { Files.deleteIfExists(scriptFile) }
             }
+            linuxTunController.onStopped()
         }
+    }
+
+    /**
+     * Waits up to [PROCESS_STOP_TIMEOUT_MS] (polling — `kill -0` checks whether the pid still exists
+     * without signaling it, the standard portable way) for a SIGTERM to take effect, escalating to
+     * SIGKILL if it doesn't. Runs entirely inside the privileged script so ONE pkexec call covers the
+     * whole escalation, instead of a second authorization prompt only for the SIGKILL step.
+     */
+    private fun killWithEscalationScript(pid: Long): String {
+        val pollIterations = PROCESS_STOP_TIMEOUT_MS / 100
+        return """
+            kill -TERM $pid 2>/dev/null || true
+            i=0
+            while kill -0 $pid 2>/dev/null; do
+                i=${'$'}((i + 1))
+                if [ ${'$'}i -ge $pollIterations ]; then kill -KILL $pid 2>/dev/null || true; break; fi
+                sleep 0.1
+            done
+        """.trimIndent()
     }
 
     /**
@@ -1520,6 +1597,9 @@ class DesktopVpnManager private constructor(
         const val TCP_CONNECT_TIMEOUT_MS = 250L
         const val PROCESS_STOP_TIMEOUT_MS = 3_000L
         const val PROCESS_KILL_TIMEOUT_MS = 1_000L
+
+        /** Tags hev-socks5-tunnel's lines on the combined Linux TUN pipe — see startOlcRtcProcess. */
+        const val HEV_LOG_PREFIX = "[hev] "
         const val DEFAULT_LOCATION_PING_PARALLELISM = 4
 
         /**

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
@@ -16,37 +16,70 @@ internal class LinuxTunController(
     private var routesInstalled = false
     private var hevBinary: Path? = null
 
-    suspend fun start(
+    /**
+     * Writes hev's config/up/down scripts and returns the command to launch it — does NOT start the
+     * process. Linux TUN needs both hev and olcRTC running as root under the SAME pkexec
+     * authorization (see DesktopVpnManager.startOlcRtcProcess's combined launch), so the caller
+     * backgrounds this command inside its own privileged process instead of us spawning it directly
+     * under a second, separate pkexec.
+     */
+    fun prepareHevLaunch(
         hevBinary: Path,
         socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
         socksUsername: String = "",
         socksPassword: String = ""
-    ): Process {
+    ): List<String> {
         this.hevBinary = hevBinary
         val upScript = writeUpScript()
         val downScript = writeDownScript()
         val config = writeConfig(socksPort, upScript, downScript, socksUsername, socksPassword)
-        val process = startPrivilegedProcess(listOf(hevBinary.toString(), config.toString()))
-        try {
-            waitForTunReady(process)
-            routesInstalled = true
-            addLog("Linux TUN connected on $TUN_NAME")
-            return process
-        } catch (e: Exception) {
-            stop(process)
-            throw e
-        }
+        return listOf(hevBinary.toString(), config.toString())
     }
 
-    suspend fun stop(process: Process?) {
-        stopProcess(process)
+    /**
+     * Polls for the TUN interface + route rule hev's up-script installs. olcRTC's own SOCKS5
+     * readiness check runs first and takes several seconds (WebRTC handshake) — hev, started earlier
+     * in the same combined launch well before olcRTC's exec, has had a comfortable head start by the
+     * time we get here, so this rarely waits long in practice.
+     */
+    suspend fun awaitReady() {
+        val deadline = System.currentTimeMillis() + TUN_READY_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            if (interfaceExists() && routeRuleExists()) {
+                routesInstalled = true
+                addLog("Linux TUN connected on $TUN_NAME")
+                return
+            }
+            delay(TUN_READY_POLL_MS)
+        }
+        error("$TUN_NAME routes were not installed")
+    }
 
+    /**
+     * Shell fragments to clean up hev + its routes as root — pkill by binary path (hev double-forks
+     * and detaches, so there is never a Process handle left to destroy()) and, if the route rule is
+     * still there, the down-script as a fallback for when hev's own pre-down-script didn't run.
+     * Returns commands only, doesn't invoke pkexec itself — the caller bundles these with olcRTC's
+     * own privileged kill into ONE combined pkexec call instead of each of us prompting separately.
+     * Best-effort by design (`|| true` throughout): always included, never gates on whether hev is
+     * actually still around, because the caller's pkexec call is happening either way (olcRTC runs
+     * as root in this mode, so an unprivileged kill can never reach it) — bundling this in is free.
+     */
+    fun privilegedCleanupCommands(): List<String> {
+        val commands = mutableListOf<String>()
+        hevBinary?.let { binary ->
+            commands += "pkill -f ${shellQuoted(binary.toString())} >/dev/null 2>&1 || true"
+        }
+        if (routesInstalled) {
+            commands += "sh ${shellQuoted(writeDownScript().toString())} >/dev/null 2>&1 || true"
+        }
+        return commands
+    }
+
+    /** Call once the combined privileged cleanup from [privilegedCleanupCommands] has actually run. */
+    suspend fun onStopped() {
         if (routesInstalled) {
             waitForRoutesRemoved()
-            if (routeRuleExists()) {
-                runCatching { runPrivilegedScript(writeDownScript()) }
-                    .onFailure { addLog("Linux TUN route cleanup failed: ${it.message}") }
-            }
             routesInstalled = false
         }
     }
@@ -93,33 +126,6 @@ internal class LinuxTunController(
         return script
     }
 
-    private suspend fun waitForTunReady(process: Process) {
-        val deadline = System.currentTimeMillis() + TUN_READY_TIMEOUT_MS
-        while (System.currentTimeMillis() < deadline) {
-            if (!process.isAlive) {
-                val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
-                error(
-                    buildString {
-                        append("hev-socks5-tunnel exited before $TUN_NAME was ready")
-                        if (output.isNotBlank()) append(": ").append(output)
-                    }
-                )
-            }
-            if (interfaceExists() && routeRuleExists()) return
-            delay(TUN_READY_POLL_MS)
-        }
-        error("$TUN_NAME routes were not installed")
-    }
-
-    private suspend fun processMatchingBinaryExists(binary: Path): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val process = ProcessBuilder("pgrep", "-f", binary.toString())
-                .redirectErrorStream(true)
-                .start()
-            process.waitFor(1, TimeUnit.SECONDS) && process.exitValue() == 0
-        }.getOrDefault(false)
-    }
-
     private suspend fun interfaceExists(): Boolean = withContext(Dispatchers.IO) {
         runCatching {
             val process = ProcessBuilder("ip", "link", "show", TUN_NAME)
@@ -156,52 +162,8 @@ internal class LinuxTunController(
         }
     }
 
-    private suspend fun runPrivilegedScript(script: Path) {
-        runPrivilegedCommand(listOf(script.toString()))
-    }
-
-    private suspend fun runPrivilegedCommand(command: List<String>): String = withContext(Dispatchers.IO) {
-        val process = ProcessBuilder(LinuxPrivilege.command(command))
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        val exitCode = process.waitFor()
-        if (exitCode != 0) {
-            error("${command.joinToString(" ")} failed with code $exitCode: $output")
-        }
-        output
-    }
-
-    private fun startPrivilegedProcess(command: List<String>): Process {
-        return ProcessBuilder(LinuxPrivilege.command(command))
-            .redirectErrorStream(true)
-            .start()
-    }
-
-    private suspend fun stopProcess(process: Process?) {
-        if (process != null && process.isAlive) {
-            process.toHandle().descendants().forEach { it.destroy() }
-            process.destroy()
-            if (!process.waitFor(PROCESS_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                process.toHandle().descendants().forEach { it.destroyForcibly() }
-                process.destroyForcibly()
-                process.waitFor(PROCESS_KILL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            }
-        }
-        // hev-socks5-tunnel daemonizes itself (double-forks and detaches), so by the time we get here
-        // the Process handle above is often already !isAlive and the block does nothing - the real
-        // privileged process has been reparented to init, still holding the TUN device open. Check
-        // unprivileged first (pgrep reads another user's /proc/*/cmdline fine, no root needed) and only
-        // escalate to a pkexec kill when something is actually still there - stop() runs on every
-        // disconnect AND on every failed connect attempt's cleanup (sometimes twice), so an unconditional
-        // pkexec call here would prompt for a second, unrelated authorization on the common path where
-        // there is nothing left to clean up.
-        hevBinary?.let { binary ->
-            if (processMatchingBinaryExists(binary)) {
-                runCatching { runPrivilegedCommand(listOf("pkill", "-f", binary.toString())) }
-            }
-        }
-    }
+    /** POSIX single-quoted: the only escape inside is closing the quote, inserting a literal ', reopening. */
+    private fun shellQuoted(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 
     internal companion object {
         const val TUN_NAME = "olcbox0"
@@ -216,8 +178,6 @@ internal class LinuxTunController(
         const val TUN_READY_TIMEOUT_MS = 10_000L
         const val TUN_READY_POLL_MS = 100L
         const val ROUTE_CLEANUP_TIMEOUT_MS = 2_000L
-        const val PROCESS_STOP_TIMEOUT_MS = 3_000L
-        const val PROCESS_KILL_TIMEOUT_MS = 1_000L
 
         /**
          * hev-socks5-tunnel bridges the TUN into the core's local SOCKS inbound. That inbound is


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

Linux TUN раньше запускал `olcRTC` и `hev-socks5-tunnel` под ДВУМЯ отдельными `pkexec`-авторизациями на каждое подключение, и до ТРЁХ отдельных `pkexec` на каждое отключение (kill olcRTC + pkill hev + fallback down-script). Теперь — по одному запросу на каждое действие:

- **Подключение**: `hev` уходит в фон под тем же `pkexec`, что и `olcRTC` (его вывод тегируется `[hev] ` и демультиплексируется обратно в существующий читающий цикл как `tun:`), затем скрипт делает `exec` в `olcRTC` — тот же pid на всём пути (`pkexec` и так делает exec, не fork), так что вся нижестоящая логика (`isAlive`/`waitFor`/`pid()`) продолжает работать без изменений.
- **Отключение**: эскалированный kill `olcRTC` (TERM → опрос → KILL прямо в шелл-скрипте, без второго `pkexec` на KILL) и очистка `hev`/маршрутов собраны в один скрипт под одним `pkexec`.

Заодно живым тестом поймали и починили: читающий цикл `rtc:`-логов падал необработанным `IOException("Stream closed")`, когда `stopProcess()` закрывал поток процесса, пока корутина была заблокирована на `readLine()` — ожидаемый способ прервать блокирующее чтение, просто не был обработан. Ловится точечно по сообщению, чтобы не проглотить реальную ошибку чтения.

## Связанный issue

нет

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`./gradlew :sharedUI:jvmTest`)
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве/эмуляторе (опиши ниже)

## Как тестировал

Оба файла — `jvmMain` (десктоп-специфичный source set), Android не затрагивают. `:androidApp:assembleDebug` не гонял — локальная сборка проверена другой командой того же уровня, `:desktopApp:packageReleaseLinuxAppImage` (компилирует тот же самый jvmMain-код), `BUILD SUCCESSFUL`. `jvmTest` зелёный.

Живой тест на реальном ПК (CachyOS/Arch, Niri): собранный AppImage, несколько циклов подключение→отключение подряд к Jitsi-локации. Один диалог авторизации на подключение, один на отключение (было 1 на подключение и до 2-3 на отключение). Проверил `yptun.log` — теги `rtc:`/`tun:` присутствуют и корректно разделены, ни одного необработанного исключения ни в одном из циклов.
