### PR TITLE
fix(android): filter MIUIInput touch spam out of the app log journal

### DIFF
--- a/YPtun/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/YPtun/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -4381,6 +4381,9 @@ class OlcboxVpnService : VpnService() {
             "/View", "/VRI[", "/HWUI", "/ViewRootImpl", "/DecorView", "/SurfaceView",
             "/InputTransport", "/InputMethodManager", "/ImeFocusController", "/ImeTracker",
             "/InsetsSourceConsumer", "/InsetsController", "/WindowOnBackDispatcher", "/WindowManager",
+            // MIUI/HyperOS-specific: logs a [MotionEvent] line per touch/swipe for EVERY app, not
+            // just this one. Absent from AOSP, so it's missing above with the rest of the input stack.
+            "/MIUIInput",
             "/BufferQueueProducer", "/BLASTBufferQueue", "/SurfaceComposerClient", "/Choreographer",
             "/OpenGLRenderer", "/AdrenoVK", "/Dialog", "/Looper", "/CustomFrequencyManager",
             "/NativeCustomFrequencyManager", "/perf_hint", "/Compiler", "/NotificationManager", "/BBA2",


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

`startLogcatCapture()` тянет весь логкат процесса (`--pid=$pid *:V`) в журнал приложения, чтобы туда попадал вывод нативных ядер, а не только `addLog()`-строки. `LOGCAT_NOISE` уже отсекал большинство Android UI/input-тегов (`/View`, `/InputTransport`, `/InputMethodManager` и т.д.), но не знал про `/MIUIInput` — MIUI/HyperOS-специфичный тег, который пишет по `[MotionEvent]`-строке на каждое касание/свайп в ЛЮБОМ приложении, не только в YPtun. AOSP его не имеет, поэтому раньше он не встречался. Из-за этого журнал захламлялся десятками нерелевантных строк при обычном пользовании приложением, что мешало читать реальные логи VPN/ядер.

Добавлена одна строка `"/MIUIInput"` в `LOGCAT_NOISE`, с комментарием, объясняющим происхождение тега.

## Связанный issue

нет

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`./gradlew :sharedUI:jvmTest`)
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве/эмуляторе (опиши ниже)

## Как тестировал

Собрал debug-APK (`:androidApp:assembleDebug`), поставил на реальный телефон (Xiaomi/HyperOS). Через `adb logcat --pid=<PID YPtun>` (тот же источник, что читает `startLogcatCapture()`) при касаниях экрана — как при активном VPN-соединении, так и без него — подтвердил, что `MIUIInput`-строки реально приходят в формате `I/MIUIInput(<pid>): [MotionEvent] ...`, попадающем под добавленный фильтр `contains("/MIUIInput")`.
