### PR TITLE
feat(core): update vendored olcRTC to fix reconnect race and vp8channel framing bug

### DIFF
--- a/olcrtc/internal/client/link.go
+++ b/olcrtc/internal/client/link.go
@@ -17,12 +17,12 @@ import (
 const peerWaitTimeout = handshake.DefaultTimeout
 
 func (c *Client) bringUpLink(ctx context.Context, cfg Config, cancel context.CancelFunc) error {
-	// LOCAL PATCH (not upstream): serialize the whole bring-up against
-	// handleReconnect. Since upstream 86173f98 moved WatchConnection ahead of
-	// the handshake, a mid-handshake drop can run handleReconnect concurrently
-	// with this function - it nils c.conn/c.pair and reopens a fresh session,
-	// which installPairLocked below would then silently overwrite with the
-	// dead one. Bounded: every step below has its own timeout.
+	// ai-generated: added this lock, held for the whole function. WatchConnection starts below,
+	// before the handshake completes, so a mid-handshake reconnect can race this call: handleReconnect
+	// takes reconnectMu too, and without serializing here it can install a fresh working session via
+	// retryHandshake while this call is still in flight, then get overwritten when this call finally
+	// reaches installPairLocked with its own, by-then-stale pair. Safe to hold: every step below is
+	// bounded by handshake.DefaultTimeout/peerWaitTimeout (15s each), not unbounded.
 	c.reconnectMu.Lock()
 	defer c.reconnectMu.Unlock()
 	linkCfg := tunnelcore.BuildTransportConfig(tunnelcore.LinkConfig{
@@ -61,11 +61,11 @@ func (c *Client) bringUpLink(ctx context.Context, cfg Config, cancel context.Can
 	// with nobody consuming it yet - a deadlock where the fix (reconnect)
 	// waits on the very handshake it needs to unstick.
 	c.goTracked(func() { link.WatchConnection(ctx) })
-	// LOCAL PATCH (not upstream): c.onData reads c.conn under sessMu from the
-	// transport delivery goroutine, which is live from link.Connect() onward,
-	// so these two writes must take the lock as well.
 	conn := muxconn.New(link, c.keys)
 	controlConn := muxconn.NewControl(link, c.keys)
+	// ai-generated: write under sessMu. onData reads c.conn under sessMu.RLock from the transport's
+	// delivery goroutine, live from the moment link.Connect() above succeeded; an unlocked write here
+	// raced it.
 	c.sessMu.Lock()
 	c.conn, c.controlConn = conn, controlConn
 	c.sessMu.Unlock()

--- a/olcrtc/internal/transport/vp8channel/kcp.go
+++ b/olcrtc/internal/transport/vp8channel/kcp.go
@@ -56,7 +56,8 @@ type kcpRuntime struct {
 	conn      *kcpConn
 	sess      *kcp.UDPSession
 	readDone  chan struct{}
-	writeMu   sync.Mutex // serializes length-prefix + payload writes
+	writeMu   sync.Mutex // serializes framed writes; also guards writeBuf
+	writeBuf  []byte     // ai-generated: framing scratch, reused under writeMu
 	closeOnce sync.Once
 }
 
@@ -133,24 +134,32 @@ func (r *kcpRuntime) setHeader(hdr [epochHdrLen]byte) {
 	r.conn.setHeader(hdr)
 }
 
-// send queues an application message for reliable delivery. The length
-// prefix + payload pair is written under a mutex so that interleaved
-// concurrent senders cannot tear the framing.
+// send queues an application message for reliable delivery. Length prefix and
+// payload go out in one Write: two writes under a mutex stop concurrent senders
+// interleaving, but do not make the pair atomic against failure. If the header
+// lands and the payload does not, the stream carries a prefix for bytes that
+// were never sent and the reader cannot resynchronise.
+//
+// ai-generated: replaced the two Write calls with a single framed write into a
+// reused buffer; added writeBuf and the cap check.
 func (r *kcpRuntime) send(msg []byte) error {
 	if len(msg) > kcpMaxMessage {
 		return ErrKCPMessageTooLarge
 	}
-	var hdr [kcpLenPrefix]byte
-	binary.BigEndian.PutUint32(hdr[:], uint32(len(msg))) //nolint:gosec,lll // G115: bounded conversion verified by surrounding logic
 
 	r.writeMu.Lock()
 	defer r.writeMu.Unlock()
 
-	if _, err := r.sess.Write(hdr[:]); err != nil {
-		return fmt.Errorf("kcp write header: %w", err)
+	need := kcpLenPrefix + len(msg)
+	if cap(r.writeBuf) < need {
+		r.writeBuf = make([]byte, need)
 	}
-	if _, err := r.sess.Write(msg); err != nil {
-		return fmt.Errorf("kcp write payload: %w", err)
+	buf := r.writeBuf[:need]
+	binary.BigEndian.PutUint32(buf[:kcpLenPrefix], uint32(len(msg))) //nolint:gosec,lll // G115: bounded conversion verified by surrounding logic
+	copy(buf[kcpLenPrefix:], msg)
+
+	if _, err := r.sess.Write(buf); err != nil {
+		return fmt.Errorf("kcp write framed message: %w", err)
 	}
 	return nil
 }

--- a/olcrtc/mobile/version.go
+++ b/olcrtc/mobile/version.go
@@ -4,7 +4,7 @@ import "log"
 
 // olcrtcVersion identifies the vendored olcRTC core build (upstream commit + update date). Bump it
 // whenever the core is re-synced from upstream; surfaced in the app's settings.
-const olcrtcVersion = "2026.08.28-f7068190"
+const olcrtcVersion = "2026.09.04-54bd269"
 
 // Version returns the olcRTC core version for display in the app.
 func Version() string { return olcrtcVersion }


### PR DESCRIPTION
<!-- Спасибо за вклад в YPtun! PR направляй в ветку `Beta`. -->

## Что делает этот PR?

Вендоренный olcRTC отставал от апстрима на 4 коммита (`f7068190` → `54bd269`, с 28.08). Среди них — **PR #146 и #147** апстрима:

- **#146**: `bringUpLink` не сериализовался с `handleReconnect` — гонка при разрыве посреди хендшейка (уже был закрыт локальным патчем в этом репо, теперь совпадает с апстримом один в один, локальный патч снят как избыточный)
- **#147**: `send()` в `vp8channel` писал 4-байтовый префикс длины и payload двумя отдельными `Write()`. При сбое записи ровно между ними в потоке оставался "осиротевший" префикс — `readLoop` терял синхронизацию границ сообщений, и все последующие фреймы читались как мусор, хотя байты приходили целыми. Похоже на вероятную причину недавних жалоб на нестабильность в чате openlibrecommunity.

Остальные локальные патчи (дефолтный Jitsi-сервер `meet.small-dm.ru`, опциональные Yandex-куки для Telemost, пробинг нескольких DNS-резолверов) переприменены поверх обновлённого дерева — апстримные коммиты их не затрагивали. `mobile/version.go` (константа версии ядра для UI) обновлена на `2026.09.04-54bd269`.

## Связанный issue

нет

## Тип изменения

- [x] 🐛 Исправление бага

## Чеклист

- [x] Ответвление от `Beta`
- [x] Собирается локально (`./gradlew :androidApp:assembleDebug -Polcbox.android.abiFilters=arm64-v8a`)
- [x] Проходят тесты (`./gradlew :sharedUI:jvmTest`)
- [x] Изменение сфокусировано на одном
- [x] Проверено на устройстве/эмуляторе (опиши ниже)

## Как тестировал

`go build ./...` в `cores/` — чисто. `:androidApp:assembleDebug` и `:desktopApp:packageReleaseLinuxAppImage` — обе сборки собрались без ошибок, debug-APK поставлен на реальный телефон (Xiaomi/HyperOS) поверх удалённой release-версии.
