### PR TITLE
fix(openflux, sub): fix MAX installer crash, harden SOCKS5 parser & preserve non-proxy sub IDs

### DIFF
--- a/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
+++ b/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
@@ -2503,7 +2503,10 @@ class LocationsRepositoryImpl(
             normalized.transport,
             normalized.id,
             normalized.key,
-            normalized.proxy?.let { "${it.type}@${it.server}:${it.serverPort}" }.orEmpty()
+            normalized.proxy?.let { "${it.type}@${it.server}:${it.serverPort}" }.orEmpty(),
+            normalized.vkturn?.let { "${it.outbound}@${it.uri.ifBlank { it.outboundProxyLink }}" }.orEmpty(),
+            normalized.masterDns?.let { "${it.domains}@${it.resolvers}" }.orEmpty(),
+            normalized.openFlux?.let { "${it.transport}@${if (it.usesMax()) it.maxUid else it.docUrl}" }.orEmpty(),
         ).joinToString("|")
     }
 

--- a/YPtun/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
+++ b/YPtun/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
@@ -937,6 +937,30 @@ class LocationsRepositoryImplTest {
         assertEquals(rigaId, locations.single { it.name == "Рига" }.storageId)
     }
 
+    @Test
+    fun freeturnSubscriptionKeepsEveryServerAndItsId() = runTest {
+        fun link(host: String, port: Int, comment: String) =
+            "freeturn://10.0.0.2:51820?server=$host&port=$port&pub=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=&comment=$comment"
+        var body = listOf(link("198.51.100.1", 443, "Нода 1"), link("198.51.100.2", 443, "Нода 2")).joinToString("\n")
+        val source = FakeLocationsDataSource()
+        val repo = LocationsRepositoryImpl(
+            dataSource = source,
+            httpClient = HttpClient(MockEngine { respond(body) }),
+            deviceIdentityProvider = StaticIdentityProvider("hwid-test")
+        )
+        val url = "https://example.test/freeturn-grow"
+        repo.importText(url)
+        val node1Id = source.stored!!.locations.single { it.name == "Нода 1" }.storageId
+
+        body = link("198.51.100.3", 443, "Нода 0") + "\n" + body
+        repo.refreshSubscription(url)
+
+        val locations = source.stored!!.locations
+        assertEquals(listOf("Нода 0", "Нода 1", "Нода 2"), locations.map { it.name })
+        assertEquals(locations.size, locations.map { it.storageId }.toSet().size)
+        assertEquals(node1Id, locations.single { it.name == "Нода 1" }.storageId)
+    }
+
     private class FakeLocationsDataSource(
         var stored: LocationBundleV4? = null,
         private val legacy: List<Pair<String, String>> = emptyList(),

--- a/YPtun/sharedUI/src/jvmSharedMain/kotlin/org/olcbox/app/vpn/openflux/SshOpenFluxServerInstaller.kt
+++ b/YPtun/sharedUI/src/jvmSharedMain/kotlin/org/olcbox/app/vpn/openflux/SshOpenFluxServerInstaller.kt
@@ -77,6 +77,11 @@ internal fun buildOpenFluxInstallScript(options: OpenFluxInstallOptions): String
     val transport = if (options.transport == OpenFluxConfig.TRANSPORT_MAX) OpenFluxConfig.TRANSPORT_MAX
     else OpenFluxConfig.TRANSPORT_YANDEX
     val rst = "OUTPUT -p tcp --tcp-flags RST RST -j DROP"
+    val execArgs = if (transport == OpenFluxConfig.TRANSPORT_MAX) {
+        "--exit-node --transport ${'$'}{OPENFLUX_TRANSPORT}"
+    } else {
+        "--exit-node --transport ${'$'}{OPENFLUX_TRANSPORT} --url ${'$'}{OPENFLUX_DOC_URL}"
+    }
     return """
         set -e
         gunzip -f /tmp/openflux.gz
@@ -103,7 +108,7 @@ internal fun buildOpenFluxInstallScript(options: OpenFluxInstallOptions): String
         [Service]
         EnvironmentFile=/etc/openflux/openflux.env
         ExecStartPre=/bin/sh -c 'iptables -C $rst 2>/dev/null || iptables -A $rst'
-        ExecStart=/usr/local/bin/openflux --exit-node --transport ${'$'}{OPENFLUX_TRANSPORT} --url ${'$'}{OPENFLUX_DOC_URL}
+        ExecStart=/usr/local/bin/openflux $execArgs
         ExecStopPost=/bin/sh -c 'iptables -D $rst 2>/dev/null || true'
         Restart=always
         RestartSec=3

--- a/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/openflux/OpenFluxInstallScriptTest.kt
+++ b/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/openflux/OpenFluxInstallScriptTest.kt
@@ -34,5 +34,8 @@ class OpenFluxInstallScriptTest {
         assertTrue(script.lines().any { it.startsWith("ExecStopPost=") && "iptables -D OUTPUT -p tcp --tcp-flags RST RST -j DROP" in it })
         assertTrue(script.lines().any { it == "OPENFLUX_TRANSPORT=\"oneme\"" })
         assertTrue(script.lines().any { it == "OPENFLUX_MAX_TOKEN=\"tok\"" })
+        val execStart = script.lines().single { it.startsWith("ExecStart=") }
+        assertTrue(execStart.endsWith("--transport \${OPENFLUX_TRANSPORT}"), execStart)
+        assertFalse("--url" in execStart, "MAX transport should not have --url on ExecStart: $execStart")
     }
 }

--- a/openflux/socks5/socks5.go
+++ b/openflux/socks5/socks5.go
@@ -94,37 +94,59 @@ func (s *SOCKS5Server) Start() error {
 func (s *SOCKS5Server) handleConnection(clientConn net.Conn) {
 	defer clientConn.Close()
 
-	buf := make([]byte, 256)
-	n, err := clientConn.Read(buf)
-	if err != nil || n < 2 || buf[0] != 0x05 {
+	head := make([]byte, 2)
+	if _, err := io.ReadFull(clientConn, head); err != nil || head[0] != 0x05 {
 		return
 	}
 
-	nMethods := int(buf[1])
-	if 2+nMethods > n {
-		nMethods = n - 2
+	methods := make([]byte, head[1])
+	if _, err := io.ReadFull(clientConn, methods); err != nil {
+		return
 	}
-	if !s.authenticate(clientConn, buf[2:2+nMethods]) {
+	if !s.authenticate(clientConn, methods) {
 		return
 	}
 
-	n, err = clientConn.Read(buf)
-	if err != nil || n < 10 || buf[1] != 0x01 {
+	reqHead := make([]byte, 4)
+	if _, err := io.ReadFull(clientConn, reqHead); err != nil || reqHead[0] != 0x05 {
+		return
+	}
+	if reqHead[1] != 0x01 {
+		// Command not supported
+		clientConn.Write([]byte{0x05, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
 		return
 	}
 
 	var targetAddr string
-	switch buf[3] {
-	case 0x01:
+	switch reqHead[3] {
+	case 0x01: // IPv4
+		addrBuf := make([]byte, 6)
+		if _, err := io.ReadFull(clientConn, addrBuf); err != nil {
+			return
+		}
 		targetAddr = fmt.Sprintf("%d.%d.%d.%d:%d",
-			buf[4], buf[5], buf[6], buf[7],
-			uint16(buf[8])<<8|uint16(buf[9]))
-	case 0x03:
-		domainLen := int(buf[4])
+			addrBuf[0], addrBuf[1], addrBuf[2], addrBuf[3],
+			uint16(addrBuf[4])<<8|uint16(addrBuf[5]))
+	case 0x03: // Domain
+		var lenBuf [1]byte
+		if _, err := io.ReadFull(clientConn, lenBuf[:]); err != nil {
+			return
+		}
+		domainLen := int(lenBuf[0])
+		domainBuf := make([]byte, domainLen+2)
+		if _, err := io.ReadFull(clientConn, domainBuf); err != nil {
+			return
+		}
 		targetAddr = fmt.Sprintf("%s:%d",
-			string(buf[5:5+domainLen]),
-			uint16(buf[5+domainLen])<<8|uint16(buf[6+domainLen]))
+			string(domainBuf[:domainLen]),
+			uint16(domainBuf[domainLen])<<8|uint16(domainBuf[domainLen+1]))
+	case 0x04: // IPv6 (OpenFlux tunnel carries IPv4 only)
+		addrBuf := make([]byte, 18)
+		_, _ = io.ReadFull(clientConn, addrBuf)
+		clientConn.Write([]byte{0x05, 0x08, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+		return
 	default:
+		clientConn.Write([]byte{0x05, 0x08, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
 		return
 	}
 

--- a/openflux/socks5/socks5_auth_test.go
+++ b/openflux/socks5/socks5_auth_test.go
@@ -62,3 +62,63 @@ func TestNoCredentialsKeepsUpstreamNoAuth(t *testing.T) {
 		t.Fatalf("reply %x, want 0500", reply)
 	}
 }
+
+type mockDialer struct {
+	dialed string
+}
+
+func (m *mockDialer) DialTCP(address string) (net.Conn, error) {
+	m.dialed = address
+	c1, c2 := net.Pipe()
+	go func() {
+		_ = c2.Close()
+	}()
+	return c1, nil
+}
+
+func TestHandleConnectionDomainAndIPv4(t *testing.T) {
+	dialer := &mockDialer{}
+	s := NewSOCKS5Server("127.0.0.1:0", dialer)
+
+	// 1. Connect to domain: example.com:443
+	server, client := net.Pipe()
+	go s.handleConnection(server)
+
+	// Auth greeting: no-auth
+	client.Write([]byte{0x05, 0x01, 0x00})
+	authResp := make([]byte, 2)
+	io.ReadFull(client, authResp)
+	if !bytes.Equal(authResp, []byte{0x05, 0x00}) {
+		t.Fatalf("auth resp: %x", authResp)
+	}
+
+	// CONNECT domain "example.com:443"
+	domain := "example.com"
+	req := append([]byte{0x05, 0x01, 0x00, 0x03, byte(len(domain))}, []byte(domain)...)
+	req = append(req, 0x01, 0xBB) // port 443
+	client.Write(req)
+
+	resp := make([]byte, 10)
+	io.ReadFull(client, resp)
+	if resp[1] != 0x00 {
+		t.Fatalf("connect resp status: %x", resp[1])
+	}
+	if dialer.dialed != "example.com:443" {
+		t.Fatalf("dialed = %q, want example.com:443", dialer.dialed)
+	}
+	client.Close()
+
+	// 2. Command not supported (e.g. UDP ASSOCIATE = 0x03)
+	server2, client2 := net.Pipe()
+	go s.handleConnection(server2)
+	client2.Write([]byte{0x05, 0x01, 0x00})
+	io.ReadFull(client2, authResp)
+
+	client2.Write([]byte{0x05, 0x03, 0x00, 0x01, 127, 0, 0, 1, 0x04, 0x38})
+	resp2 := make([]byte, 10)
+	io.ReadFull(client2, resp2)
+	if resp2[1] != 0x07 { // 0x07 = Command not supported
+		t.Fatalf("expected command not supported 0x07, got %x", resp2[1])
+	}
+	client2.Close()
+}

--- a/openflux/transport/oneme/max_transport.go
+++ b/openflux/transport/oneme/max_transport.go
@@ -1,6 +1,8 @@
 package oneme
 
 import (
+	"fmt"
+
 	"universal-bypass-tool/transport"
 	"universal-bypass-tool/utils"
 )
@@ -11,7 +13,7 @@ type OneMeTransport struct {
 	uid   int64
 	exit  bool
 
-	oneMeClient MaxClient
+	oneMeClient *MaxClient
 	ch          *CallHandler
 }
 
@@ -34,16 +36,20 @@ func NewOneMeTransport(isExit bool, maxToken string, maxUid int64, config transp
 
 func (t *OneMeTransport) Start() error {
 	utils.Debugf("creating max client ...")
-	t.oneMeClient = *NewMaxClient()
-	t.oneMeClient.Connect()
-	t.oneMeClient.LoginByToken(t.token)
+	t.oneMeClient = NewMaxClient()
+	if err := t.oneMeClient.Connect(); err != nil {
+		return fmt.Errorf("connect max: %w", err)
+	}
+	if err := t.oneMeClient.LoginByToken(t.token); err != nil {
+		return fmt.Errorf("login max: %w", err)
+	}
 
 	if t.exit {
 		utils.Debugf("configured ch for exit node")
-		t.ch = startIncomingListener(&t.oneMeClient)
+		t.ch = startIncomingListener(t.oneMeClient)
 	} else {
 		utils.Debugf("configured ch for client mode")
-		t.ch = startOutgoingCall(&t.oneMeClient, t.uid)
+		t.ch = startOutgoingCall(t.oneMeClient, t.uid)
 	}
 
 	utils.Debugf("configured dc inbound")

--- a/openflux/yptun_client.go
+++ b/openflux/yptun_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,8 +70,12 @@ type cachedIP struct {
 const dnsCacheTTL = 5 * time.Minute
 
 func newTunnelResolvingDialer(tun *tunnel.TCPTunnel, dnsServer string) socks5.Dialer {
+	dnsServer = strings.TrimSpace(dnsServer)
 	if dnsServer == "" {
 		return tun // upstream behaviour: system resolver
+	}
+	if !strings.Contains(dnsServer, ":") {
+		dnsServer = net.JoinHostPort(dnsServer, "53")
 	}
 	return &tunnelResolvingDialer{
 		tun: tun,


### PR DESCRIPTION
### Что делает этот PR
1. **OpenFlux VPS Installer (`SshOpenFluxServerInstaller`)**: убирает безусловную передачу флага `--url` в systemd `ExecStart`. Для транспорта MAX (`oneme`) `docUrl` пустой, из-за чего парсер флагов Go падал с `flag needs an argument: -url`, и `openflux.service` не запускался на VPS.
2. **Стабильность ID в подписках (`LocationsDatasource`)**: расширяет `subscriptionSignature()` для поддержки `vkturn` (`freeturn://`), `masterDns` и `openFlux`. Ранее они все отдавали пустую сигнатуру четырех пайпов, из-за чего при обновлении подписки происходил сдвиг позиций и сброс сохраненных ID серверов.
3. **OpenFlux SOCKS5 парсер (`socks5.go`)**: чтение заголовков и доменных имен переведено на `io.ReadFull`, устранена потенциальная паника `slice bounds out of range` при фрагментированных TCP пакетах, добавлены стандартные ответы ошибок RFC 1928 вместо зависания соединения.
4. **OpenFlux MAX Transport (`max_transport.go`)**: убрано копирование структуры с `sync.Mutex` / `atomic.Int64`, добавлена обработка ошибок `Connect()` и `LoginByToken()`.
5. **OpenFlux DNS Dialer (`yptun_client.go`)**: добавлено автоматическое добавление порта `:53`, если DNS указан без порта.

### Связанные issues
- Найдено в процессе код-ревью свежих коммитов `Beta` (v348).

### Тип изменения
- [x] 🐛 Исправление бага (non-breaking change, исправляет критические ошибки)
- [x] 🧪 Новые тесты

### Чеклист
- [x] Ветка ответвлена от актуального `Beta`
- [x] Добавлен unit-тест `OpenFluxInstallScriptTest.kt` для проверки `ExecStart` без `--url`
- [x] Добавлен unit-тест `freeturnSubscriptionKeepsEveryServerAndItsId` в `LocationsRepositoryImplTest.kt`
- [x] Добавлены тесты `socks5_auth_test.go`
