### PR TITLE
feat(desktop/linux): полная поддержка Linux (TUN режим для всех ядер, GNOME/KDE системный прокси, deep links)

### DIFF
--- a/.github/workflows/linux-deb.yml
+++ b/.github/workflows/linux-deb.yml
@@ -16,6 +16,7 @@ on:
       - "v*"
     branches:
       - pc-client-beta
+      - Beta
     paths:
       - ".github/workflows/linux-deb.yml"
       - "YPtun/desktopApp/**"
@@ -31,7 +32,7 @@ permissions:
 
 jobs:
   build:
-    name: ${{ matrix.arch }} .deb
+    name: ${{ matrix.arch }} packages
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:
@@ -58,12 +59,15 @@ jobs:
           go-version-file: cores/go.mod
           cache: false
 
-      # fakeroot + dpkg-dev are what jpackage shells out to for --type deb. The X/GTK dev headers are
-      # not needed to build (skiko ships prebuilt natives), only at runtime on the user's machine.
+      # fakeroot + dpkg-dev are what jpackage shells out to for --type deb.
       - name: Install packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends fakeroot dpkg-dev binutils
+          sudo apt-get install -y --no-install-recommends fakeroot dpkg-dev binutils file wget
+          if [ "${{ matrix.arch }}" = "amd64" ]; then
+            sudo wget -O /usr/local/bin/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage || true
+            sudo chmod +x /usr/local/bin/appimagetool || true
+          fi
 
       # Gradle configures every project including the Android modules, and AGP refuses to configure
       # without a valid SDK location. Nothing is installed - no Android task runs here.
@@ -82,16 +86,16 @@ jobs:
 
       # --no-daemon --max-workers=1: the Exec tasks shell out to `go build` and must inherit this
       # environment, which a reused daemon does not pick up.
-      - name: Build .deb
+      - name: Build packages
         working-directory: YPtun
         env:
           CGO_ENABLED: "1"
-        # The repo is maintained from Windows, so gradlew is committed as mode 100644 and is not
-        # executable on checkout. Set the bit here rather than changing the recorded mode, which would
-        # also land on the Android branches when this one is merged.
         run: |
           chmod +x ./gradlew
           ./gradlew --no-daemon --max-workers=1 :desktopApp:packageReleaseDeb --stacktrace
+          if [ "${{ matrix.arch }}" = "amd64" ] && [ -x /usr/local/bin/appimagetool ]; then
+            APPIMAGETOOL="/usr/local/bin/appimagetool --appimage-extract-and-run" ./gradlew --no-daemon --max-workers=1 :desktopApp:packageReleaseLinuxAppImage || true
+          fi
 
       - name: Verify the package
         run: |
@@ -107,18 +111,22 @@ jobs:
           [ "$got" = "$expected" ] || { echo "deb Architecture=$got, expected $expected"; exit 1; }
           echo "OK: $expected"
 
-      - name: Rename for release
+      - name: Prepare artifacts for release
         run: |
           set -eu
           deb=$(find YPtun/desktopApp/build/compose/binaries -name '*.deb' | head -1)
           ver=$(grep '^olcbox.version=' YPtun/gradle.properties | cut -d= -f2)
           mkdir -p dist
           cp "$deb" "dist/YPtun-${ver}-${{ matrix.arch }}.deb"
+          appimage=$(find YPtun/desktopApp/build/compose/binaries -name '*.AppImage' | head -1 || true)
+          if [ -n "$appimage" ]; then
+            cp "$appimage" "dist/YPtun-${ver}-${{ matrix.arch }}.AppImage"
+          fi
           ls -la dist
 
       - uses: actions/upload-artifact@v4
         with:
-          name: yptun-linux-${{ matrix.arch }}-deb
-          path: dist/*.deb
+          name: yptun-linux-${{ matrix.arch }}-packages
+          path: dist/*
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/linux-deb.yml
+++ b/.github/workflows/linux-deb.yml
@@ -65,10 +65,14 @@ jobs:
       - name: Install packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends fakeroot dpkg-dev binutils file wget
+          sudo apt-get install -y --no-install-recommends fakeroot dpkg-dev binutils file wget libfuse2
           if [ "${{ matrix.arch }}" = "amd64" ]; then
-            sudo wget -O /usr/local/bin/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage || true
-            sudo chmod +x /usr/local/bin/appimagetool || true
+            sudo wget -O /usr/local/bin/appimagetool.bin https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage || true
+            if [ -f /usr/local/bin/appimagetool.bin ]; then
+              sudo chmod +x /usr/local/bin/appimagetool.bin
+              sudo sh -c 'printf "#!/bin/sh\nexec /usr/local/bin/appimagetool.bin --appimage-extract-and-run \"\$@\"\n" > /usr/local/bin/appimagetool'
+              sudo chmod +x /usr/local/bin/appimagetool
+            fi
           fi
 
       # Gradle configures every project including the Android modules, and AGP refuses to configure
@@ -96,7 +100,7 @@ jobs:
           chmod +x ./gradlew
           ./gradlew --no-daemon --max-workers=1 :desktopApp:packageReleaseDeb --stacktrace
           if [ "${{ matrix.arch }}" = "amd64" ] && [ -x /usr/local/bin/appimagetool ]; then
-            APPIMAGETOOL="/usr/local/bin/appimagetool --appimage-extract-and-run" ./gradlew --no-daemon --max-workers=1 :desktopApp:packageReleaseLinuxAppImage || true
+            ./gradlew --no-daemon --max-workers=1 :desktopApp:packageReleaseLinuxAppImage || true
           fi
 
       - name: Verify the package

--- a/.github/workflows/linux-deb.yml
+++ b/.github/workflows/linux-deb.yml
@@ -17,6 +17,8 @@ on:
     branches:
       - pc-client-beta
       - Beta
+      - main
+      - "feature/**"
     paths:
       - ".github/workflows/linux-deb.yml"
       - "YPtun/desktopApp/**"

--- a/YPtun/desktopApp/build.gradle.kts
+++ b/YPtun/desktopApp/build.gradle.kts
@@ -976,10 +976,12 @@ if (currentBuildOs.isLinux) {
             [Desktop Entry]
             Type=Application
             Name=$desktopPackageName
-            Exec=$desktopPackageName
+            Comment=Fast, versatile VPN client to bypass censorship
+            Exec=$desktopPackageName %u
             Icon=olcbox
             Categories=Network;Utility;
             Terminal=false
+            MimeType=x-scheme-handler/yptun;x-scheme-handler/vless;x-scheme-handler/vmess;x-scheme-handler/ss;x-scheme-handler/trojan;x-scheme-handler/hysteria2;x-scheme-handler/tuic;
             DESKTOP
 
             cp "${'$'}icon_file" "${'$'}target_dir/olcbox.png"

--- a/YPtun/desktopApp/src/main/kotlin/main.kt
+++ b/YPtun/desktopApp/src/main/kotlin/main.kt
@@ -253,9 +253,9 @@ fun main(args: Array<String>) {
     val relaunchedAfterElevation = DesktopElevation.STARTUP_ELEVATION_ARGUMENT in args ||
         WINDOWS_ELEVATED_START_ARGUMENT in args
     val claimed = if (relaunchedAfterElevation) {
-        DesktopSingleInstance.claimAfterPredecessorExits(::requestWindowToFront)
+        DesktopSingleInstance.claimAfterPredecessorExits(::handleInstanceCommand)
     } else {
-        DesktopSingleInstance.claim(::requestWindowToFront)
+        DesktopSingleInstance.claimWithArgs(args, ::handleInstanceCommand)
     }
     if (!claimed) return
 
@@ -263,15 +263,18 @@ fun main(args: Array<String>) {
 }
 
 /**
- * Set by the running app so a second launch can raise its window (see [DesktopSingleInstance]).
+ * Set by the running app so a second launch can raise its window or pass an import link.
  * Held here rather than inside the composition because it is called from a plain socket thread.
  */
 @Volatile
-private var showWindowRequest: (() -> Unit)? = null
+private var instanceCommandHandler: ((String) -> Unit)? = null
 
-private fun requestWindowToFront() {
-    val request = showWindowRequest ?: return
-    javax.swing.SwingUtilities.invokeLater { runCatching { request() } }
+private fun handleInstanceCommand(command: String) {
+    javax.swing.SwingUtilities.invokeLater {
+        runCatching {
+            instanceCommandHandler?.invoke(command)
+        }
+    }
 }
 
 /**
@@ -431,6 +434,15 @@ private fun runApp(args: Array<String>) = application {
         if (WINDOWS_ELEVATED_START_ARGUMENT in args) {
             dependencies.homeViewModel.loadCurrentConfig {
                 dependencies.homeViewModel.ToggleVpn()
+            }
+        }
+        val startupLink = args.firstOrNull { it.contains("://") || it.startsWith("vless:") || it.startsWith("vmess:") }
+        if (!startupLink.isNullOrBlank()) {
+            dependencies.homeViewModel.importConfig(startupLink) {
+                dependencies.locationViewModel.loadLocations {
+                    dependencies.homeViewModel.loadCurrentConfig()
+                }
+                desktopNotice = strings().importedFromClipboard
             }
         }
         // Launch check, then re-check while the app sits in the tray; checkUpdate skips ticks until
@@ -808,9 +820,9 @@ private fun runApp(args: Array<String>) = application {
             }
         }
 
-        // A second launch of the .exe hands its "show yourself" here instead of starting a duplicate.
+        // A second launch hands its "show" or imported link here instead of starting a duplicate.
         DisposableEffect(Unit) {
-            showWindowRequest = {
+            instanceCommandHandler = { cmd ->
                 isWindowVisible = true
                 runCatching {
                     window.isVisible = true
@@ -818,8 +830,19 @@ private fun runApp(args: Array<String>) = application {
                     window.toFront()
                     window.requestFocus()
                 }
+                val link = cmd.removePrefix("show").trim()
+                if (link.isNotBlank() && (link.contains("://") || link.startsWith("vless:") || link.startsWith("vmess:"))) {
+                    scope.launch {
+                        dependencies.homeViewModel.importConfig(link) {
+                            dependencies.locationViewModel.loadLocations {
+                                dependencies.homeViewModel.loadCurrentConfig()
+                            }
+                            desktopNotice = strings().importedFromClipboard
+                        }
+                    }
+                }
             }
-            onDispose { showWindowRequest = null }
+            onDispose { instanceCommandHandler = null }
         }
 
         val dynamicTheme by dependencies.settings.dynamicTheme.collectAsState()

--- a/YPtun/desktopApp/src/main/kotlin/main.kt
+++ b/YPtun/desktopApp/src/main/kotlin/main.kt
@@ -438,12 +438,12 @@ private fun runApp(args: Array<String>) = application {
         }
         val startupLink = args.firstOrNull { it.contains("://") || it.startsWith("vless:") || it.startsWith("vmess:") }
         if (!startupLink.isNullOrBlank()) {
-            dependencies.homeViewModel.importConfig(startupLink) {
+            dependencies.homeViewModel.onImportFullConfig(startupLink, onComplete = {
                 dependencies.locationViewModel.loadLocations {
                     dependencies.homeViewModel.loadCurrentConfig()
                 }
                 desktopNotice = strings().importedFromClipboard
-            }
+            })
         }
         // Launch check, then re-check while the app sits in the tray; checkUpdate skips ticks until
         // the chosen interval (1–24 h) has passed.
@@ -833,12 +833,12 @@ private fun runApp(args: Array<String>) = application {
                 val link = cmd.removePrefix("show").trim()
                 if (link.isNotBlank() && (link.contains("://") || link.startsWith("vless:") || link.startsWith("vmess:"))) {
                     scope.launch {
-                        dependencies.homeViewModel.importConfig(link) {
+                        dependencies.homeViewModel.onImportFullConfig(link, onComplete = {
                             dependencies.locationViewModel.loadLocations {
                                 dependencies.homeViewModel.loadCurrentConfig()
                             }
                             desktopNotice = strings().importedFromClipboard
-                        }
+                        })
                     }
                 }
             }

--- a/YPtun/gradle.properties
+++ b/YPtun/gradle.properties
@@ -18,7 +18,7 @@ compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
 olcbox.version=3.5.0
-olcbox.versionCode=355
+olcbox.versionCode=356
 # Идентичность приложения для Android. Переезд состоялся в 3.3.2: мост (LegacyExportProvider) уехал
 # в 3.3.1, поэтому сборка с новым id ставится РЯДОМ со старой и при первом запуске забирает её данные
 # (LegacyMigration.runIfNeeded), после чего один раз предлагает удалить старую установку.

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/desktop/DesktopSingleInstance.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/desktop/DesktopSingleInstance.kt
@@ -39,7 +39,14 @@ object DesktopSingleInstance {
      *
      * [onShowRequested] is called — off the UI thread — whenever a later launch asks for the window.
      */
-    fun claim(onShowRequested: () -> Unit): Boolean {
+    /**
+     * Claims ownership. Returns true when this process is the one instance and may continue; false
+     * when another copy is already running (it has been told to show itself and this process must
+     * exit immediately, without a window).
+     *
+     * [onCommandReceived] is called — off the UI thread — with the command or arguments passed by a later launch.
+     */
+    fun claim(onCommandReceived: (String) -> Unit): Boolean {
         val loopback = InetAddress.getLoopbackAddress()
         val server = try {
             ServerSocket().apply {
@@ -47,11 +54,35 @@ object DesktopSingleInstance {
                 bind(InetSocketAddress(loopback, PORT))
             }
         } catch (e: IOException) {
-            notifyOwner()
+            notifyOwner(SHOW_COMMAND)
             return false
         }
         listener = server
-        Thread({ acceptLoop(server, onShowRequested) }, "YPtunSingleInstance").apply {
+        Thread({ acceptLoop(server, onCommandReceived) }, "YPtunSingleInstance").apply {
+            isDaemon = true
+            start()
+        }
+        return true
+    }
+
+    /**
+     * Overload for claim with CLI arguments: if another instance is running, passes the arguments
+     * (e.g. imported deep links) to it before exiting.
+     */
+    fun claimWithArgs(args: Array<String>, onCommandReceived: (String) -> Unit): Boolean {
+        val loopback = InetAddress.getLoopbackAddress()
+        val server = try {
+            ServerSocket().apply {
+                reuseAddress = false
+                bind(InetSocketAddress(loopback, PORT))
+            }
+        } catch (e: IOException) {
+            val command = if (args.isEmpty()) SHOW_COMMAND else "$SHOW_COMMAND ${args.joinToString(" ")}"
+            notifyOwner(command)
+            return false
+        }
+        listener = server
+        Thread({ acceptLoop(server, onCommandReceived) }, "YPtunSingleInstance").apply {
             isDaemon = true
             start()
         }
@@ -63,7 +94,7 @@ object DesktopSingleInstance {
      * elevated: the old process is still alive for a moment, and it must NOT be mistaken for a
      * duplicate — it is the very process being replaced.
      */
-    fun claimAfterPredecessorExits(onShowRequested: () -> Unit, timeoutMs: Long = 10_000): Boolean {
+    fun claimAfterPredecessorExits(onCommandReceived: (String) -> Unit, timeoutMs: Long = 10_000): Boolean {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
             val loopback = InetAddress.getLoopbackAddress()
@@ -77,7 +108,7 @@ object DesktopSingleInstance {
                 continue
             }
             listener = server
-            Thread({ acceptLoop(server, onShowRequested) }, "YPtunSingleInstance").apply {
+            Thread({ acceptLoop(server, onCommandReceived) }, "YPtunSingleInstance").apply {
                 isDaemon = true
                 start()
             }
@@ -93,7 +124,7 @@ object DesktopSingleInstance {
         listener = null
     }
 
-    private fun acceptLoop(server: ServerSocket, onShowRequested: () -> Unit) {
+    private fun acceptLoop(server: ServerSocket, onCommandReceived: (String) -> Unit) {
         while (true) {
             val client = try {
                 server.accept()
@@ -104,18 +135,18 @@ object DesktopSingleInstance {
                 client.use {
                     it.soTimeout = 2_000
                     val line = it.getInputStream().bufferedReader().readLine()
-                    if (line?.trim() == SHOW_COMMAND) onShowRequested()
+                    if (!line.isNullOrBlank()) onCommandReceived(line.trim())
                 }
             }
         }
     }
 
     /** Best-effort "you are already running, come to the front". */
-    private fun notifyOwner() {
+    private fun notifyOwner(command: String = SHOW_COMMAND) {
         runCatching {
             Socket().use { socket ->
                 socket.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), PORT), 2_000)
-                socket.getOutputStream().write("$SHOW_COMMAND\n".toByteArray(Charsets.US_ASCII))
+                socket.getOutputStream().write("$command\n".toByteArray(Charsets.UTF_8))
                 socket.getOutputStream().flush()
             }
         }

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopSocksProxySettings.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopSocksProxySettings.kt
@@ -1,8 +1,8 @@
 package org.olcbox.app.vpn
 
 import kotlinx.serialization.Serializable
-import org.olcbox.app.vpn.desktop.DesktopOs
-import org.olcbox.app.vpn.desktop.DesktopPaths
+import org.olcbox.app.desktop.DesktopOs
+import org.olcbox.app.desktop.DesktopPaths
 import org.olcbox.app.vpn.desktop.PacServer
 
 @Serializable

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopSocksProxySettings.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopSocksProxySettings.kt
@@ -1,6 +1,8 @@
 package org.olcbox.app.vpn
 
 import kotlinx.serialization.Serializable
+import org.olcbox.app.vpn.desktop.DesktopOs
+import org.olcbox.app.vpn.desktop.DesktopPaths
 import org.olcbox.app.vpn.desktop.PacServer
 
 @Serializable
@@ -21,9 +23,11 @@ data class DesktopSocksProxySettings(
 
     fun normalized(): DesktopSocksProxySettings {
         // Unsecured is the default shape: no credentials, standard proxy port.
+        // On Linux, port 8080 is commonly used by other software (e.g. Steam's steamwebhelper),
+        // so we fall back to LOCAL_SOCKS_PORT (10808) which avoids that conflict.
         if (!secured) return copy(
             host = host.ifBlank { PacServer.LOCAL_SOCKS_HOST },
-            port = UNSECURED_PORT,
+            port = unsecuredPort(),
             username = "",
             password = ""
         )
@@ -42,6 +46,17 @@ data class DesktopSocksProxySettings(
 
         /** Port used when [secured] is off — the default proxy port Windows/browsers expect. */
         const val UNSECURED_PORT = 8080
+
+        /**
+         * Returns the unsecured SOCKS port for the current platform.
+         * Windows uses 8080 (conventional browser proxy port).
+         * Linux uses LOCAL_SOCKS_PORT (10808) to avoid conflicts with common services
+         * (e.g. Steam's steamwebhelper occupies 8080 on Steam Deck).
+         */
+        fun unsecuredPort(): Int = when (DesktopPaths.os) {
+            DesktopOs.Windows -> UNSECURED_PORT
+            else -> PacServer.LOCAL_SOCKS_PORT
+        }
 
         fun isValidPort(port: Int): Boolean = port in MIN_PORT..MAX_PORT
 

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -753,7 +753,12 @@ class DesktopVpnManager private constructor(
             val bridgeSettings = socksSettings
 
             when (desktopMode) {
-                DesktopMode.LinuxTun -> startLinuxTun(requestGeneration = requestGeneration)
+                DesktopMode.LinuxTun -> startLinuxTun(
+                    socksPort = bridgeSettings.port,
+                    requestGeneration = requestGeneration,
+                    socksUsername = bridgeSettings.username,
+                    socksPassword = bridgeSettings.password
+                )
                 DesktopMode.WindowsTun -> if (engineController.tunHandledInCore) {
                     // sing-box raised the wintun adapter itself (per-process split tunneling);
                     // no external tun2socks needed.
@@ -868,14 +873,30 @@ class DesktopVpnManager private constructor(
     }
 
     /**
-     * hev itself was already launched — backgrounded inside the SAME combined pkexec call that
-     * started olcRTC (see startOlcRtcProcess/writeLinuxTunLaunchScript) — so all that's left here is
-     * waiting for its up-script to actually install the TUN interface + route. [tunProcess] stays
-     * null in this mode: there is no separate Process handle for hev, its output already rides
-     * olcRTC's own (tagged "tun: ", split out in the reader loop there).
+     * For olcRTC (subprocess), hev was already launched inside the SAME combined pkexec call that
+     * started olcRTC (see startOlcRtcProcess/writeLinuxTunLaunchScript), so we only await readiness.
+     * For non-olcRTC engines (sing-box, xray, amneziawg, etc.), the core runs in-process via yptuncore,
+     * so hev-socks5-tunnel must be started here as a standalone privileged process.
      */
-    private suspend fun startLinuxTun(requestGeneration: Long) {
-        linuxTunController.awaitReady()
+    private suspend fun startLinuxTun(
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
+        requestGeneration: Long,
+        socksUsername: String = "",
+        socksPassword: String = ""
+    ) {
+        if (process == null) {
+            // In-process engine (sing-box / xray / awg / openflux / etc.): launch standalone hev
+            val hevBinary = DesktopNativeAssets.resolveHevSocks5TunnelBinary()
+            tunProcess = linuxTunController.start(
+                hevBinary = hevBinary,
+                socksPort = socksPort,
+                socksUsername = socksUsername,
+                socksPassword = socksPassword
+            )
+        } else {
+            // olcRTC subprocess: hev was already started by the combined wrapper script
+            linuxTunController.awaitReady()
+        }
 
         if (requestGeneration != generation) {
             throw CancellationException("Desktop start superseded")
@@ -1041,8 +1062,16 @@ class DesktopVpnManager private constructor(
         when (stoppingDesktopMode) {
             // Cleanup (hev + routes, bundled with olcRTC's own kill into one pkexec call) happens
             // below via stopProcess(process, privileged = ...) — see LinuxTunController.onStopped.
+            // For in-process engines, tunProcess was started separately and is cleaned up here.
             DesktopMode.LinuxTun -> {
-                tunProcess = null
+                if (tunProcess != null) {
+                    runCatching {
+                        linuxTunController.stop(tunProcess)
+                    }.onFailure {
+                        addLog("Linux TUN stop failed: ${it.message}")
+                    }
+                    tunProcess = null
+                }
             }
             DesktopMode.WindowsTun -> {
                 runCatching {

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -33,7 +33,7 @@ internal interface DesktopProxyController {
             return when (DesktopPaths.os) {
                 DesktopOs.MacOS -> MacOsProxyController()
                 DesktopOs.Windows -> WindowsProxyController()
-                DesktopOs.Linux -> UnsupportedProxyController()
+                DesktopOs.Linux -> LinuxProxyController()
                 DesktopOs.Other -> UnsupportedProxyController()
             }
         }
@@ -42,11 +42,197 @@ internal interface DesktopProxyController {
 
 internal class UnsupportedProxyController : DesktopProxyController {
     override suspend fun enable(httpProxyHostPort: String, pacUrl: String) {
-        error("System proxy mode supports macOS and Windows")
+        error("System proxy mode is not supported on this platform")
     }
 
     override suspend fun restore() = Unit
     override suspend fun clearStaleProxy() = Unit
+}
+
+internal data class LinuxGnomeProxyState(
+    val mode: String,
+    val httpHost: String,
+    val httpPort: Int,
+    val httpsHost: String,
+    val httpsPort: Int,
+    val ignoreHosts: String
+) {
+    fun looksLikeOurs(): Boolean =
+        (httpHost.contains("127.0.0.1") || httpHost.contains("localhost")) &&
+        (mode == "'manual'" || mode == "manual")
+}
+
+internal data class LinuxKdeProxyState(
+    val proxyType: String,
+    val httpProxy: String,
+    val httpsProxy: String
+) {
+    fun looksLikeOurs(): Boolean =
+        (httpProxy.contains("127.0.0.1") || httpProxy.contains("localhost")) &&
+        (proxyType == "1" || proxyType == "2")
+}
+
+internal class LinuxProxyController : DesktopProxyController {
+    private var gnomeBackup: LinuxGnomeProxyState? = null
+    private var kdeBackup: LinuxKdeProxyState? = null
+
+    override suspend fun enable(httpProxyHostPort: String, pacUrl: String) {
+        val host = httpProxyHostPort.substringBefore(':')
+        val port = httpProxyHostPort.substringAfter(':', "8080").toIntOrNull() ?: 8080
+
+        if (hasGsettings()) {
+            val current = readGnomeState()
+            if (current != null && !current.looksLikeOurs()) {
+                gnomeBackup = current
+            }
+            enableGnomeProxyCommands(host, port).forEach { cmd ->
+                runCatching { runCommand(cmd) }
+            }
+        }
+
+        if (hasKdeConfig()) {
+            val current = readKdeState()
+            if (current != null && !current.looksLikeOurs()) {
+                kdeBackup = current
+            }
+            enableKdeProxyCommands("http://$httpProxyHostPort").forEach { cmd ->
+                runCatching { runCommand(cmd) }
+            }
+        }
+    }
+
+    override suspend fun restore() {
+        gnomeBackup?.let { state ->
+            restoreGnomeProxyCommands(state).forEach { cmd ->
+                runCatching { runCommand(cmd) }
+            }
+            gnomeBackup = null
+        } ?: run {
+            if (hasGsettings()) {
+                disableGnomeProxyCommands().forEach { cmd ->
+                    runCatching { runCommand(cmd) }
+                }
+            }
+        }
+
+        kdeBackup?.let { state ->
+            restoreKdeProxyCommands(state).forEach { cmd ->
+                runCatching { runCommand(cmd) }
+            }
+            kdeBackup = null
+        } ?: run {
+            if (hasKdeConfig()) {
+                disableKdeProxyCommands().forEach { cmd ->
+                    runCatching { runCommand(cmd) }
+                }
+            }
+        }
+    }
+
+    override suspend fun clearStaleProxy() {
+        if (hasGsettings()) {
+            val current = readGnomeState()
+            if (current != null && current.looksLikeOurs()) {
+                disableGnomeProxyCommands().forEach { cmd ->
+                    runCatching { runCommand(cmd) }
+                }
+            }
+        }
+        if (hasKdeConfig()) {
+            val current = readKdeState()
+            if (current != null && current.looksLikeOurs()) {
+                disableKdeProxyCommands().forEach { cmd ->
+                    runCatching { runCommand(cmd) }
+                }
+            }
+        }
+    }
+
+    private suspend fun hasGsettings(): Boolean = runCatching {
+        val out = runCommand(listOf("which", "gsettings"))
+        out.isNotBlank()
+    }.getOrDefault(false)
+
+    private suspend fun hasKdeConfig(): Boolean = runCatching {
+        val out = runCommand(listOf("which", "kwriteconfig5")).ifBlank {
+            runCatching { runCommand(listOf("which", "kwriteconfig6")) }.getOrDefault("")
+        }
+        out.isNotBlank()
+    }.getOrDefault(false)
+
+    private suspend fun kdeConfigBinary(): String = runCatching {
+        val which6 = runCatching { runCommand(listOf("which", "kwriteconfig6")) }.getOrDefault("")
+        if (which6.isNotBlank()) "kwriteconfig6" else "kwriteconfig5"
+    }.getOrDefault("kwriteconfig5")
+
+    private suspend fun kdeReadBinary(): String = runCatching {
+        val which6 = runCatching { runCommand(listOf("which", "kreadconfig6")) }.getOrDefault("")
+        if (which6.isNotBlank()) "kreadconfig6" else "kreadconfig5"
+    }.getOrDefault("kreadconfig5")
+
+    private suspend fun readGnomeState(): LinuxGnomeProxyState? = runCatching {
+        val mode = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy", "mode")).trim()
+        val httpHost = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy.http", "host")).trim()
+        val httpPort = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy.http", "port")).trim().toIntOrNull() ?: 0
+        val httpsHost = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy.https", "host")).trim()
+        val httpsPort = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy.https", "port")).trim().toIntOrNull() ?: 0
+        val ignoreHosts = runCommand(listOf("gsettings", "get", "org.gnome.system.proxy", "ignore-hosts")).trim()
+        LinuxGnomeProxyState(mode, httpHost, httpPort, httpsHost, httpsPort, ignoreHosts)
+    }.getOrNull()
+
+    private suspend fun readKdeState(): LinuxKdeProxyState? = runCatching {
+        val readBin = kdeReadBinary()
+        val proxyType = runCommand(listOf(readBin, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType")).trim()
+        val httpProxy = runCommand(listOf(readBin, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy")).trim()
+        val httpsProxy = runCommand(listOf(readBin, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy")).trim()
+        LinuxKdeProxyState(proxyType, httpProxy, httpsProxy)
+    }.getOrNull()
+
+    companion object {
+        fun enableGnomeProxyCommands(host: String, port: Int): List<List<String>> = listOf(
+            listOf("gsettings", "set", "org.gnome.system.proxy.http", "host", host),
+            listOf("gsettings", "set", "org.gnome.system.proxy.http", "port", port.toString()),
+            listOf("gsettings", "set", "org.gnome.system.proxy.https", "host", host),
+            listOf("gsettings", "set", "org.gnome.system.proxy.https", "port", port.toString()),
+            listOf("gsettings", "set", "org.gnome.system.proxy", "ignore-hosts", "['localhost', '127.0.0.0/8', '::1']"),
+            listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "manual")
+        )
+
+        fun disableGnomeProxyCommands(): List<List<String>> = listOf(
+            listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "none")
+        )
+
+        fun restoreGnomeProxyCommands(state: LinuxGnomeProxyState): List<List<String>> = buildList {
+            if (state.mode == "'none'" || state.mode == "none") {
+                add(listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "none"))
+            } else {
+                add(listOf("gsettings", "set", "org.gnome.system.proxy.http", "host", state.httpHost.trim('\'')))
+                add(listOf("gsettings", "set", "org.gnome.system.proxy.http", "port", state.httpPort.toString()))
+                add(listOf("gsettings", "set", "org.gnome.system.proxy.https", "host", state.httpsHost.trim('\'')))
+                add(listOf("gsettings", "set", "org.gnome.system.proxy.https", "port", state.httpsPort.toString()))
+                add(listOf("gsettings", "set", "org.gnome.system.proxy", "ignore-hosts", state.ignoreHosts))
+                add(listOf("gsettings", "set", "org.gnome.system.proxy", "mode", state.mode.trim('\'')))
+            }
+        }
+
+        fun enableKdeProxyCommands(proxyUrl: String, binary: String = "kwriteconfig5"): List<List<String>> = listOf(
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "1"),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy", proxyUrl),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy", proxyUrl)
+        )
+
+        fun disableKdeProxyCommands(binary: String = "kwriteconfig5"): List<List<String>> = listOf(
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "0"),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy", ""),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy", "")
+        )
+
+        fun restoreKdeProxyCommands(state: LinuxKdeProxyState, binary: String = "kwriteconfig5"): List<List<String>> = listOf(
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", state.proxyType.ifBlank { "0" }),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy", state.httpProxy),
+            listOf(binary, "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy", state.httpsProxy)
+        )
+    }
 }
 
 internal data class MacOsAutoProxyState(

--- a/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
+++ b/YPtun/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
@@ -18,10 +18,7 @@ internal class LinuxTunController(
 
     /**
      * Writes hev's config/up/down scripts and returns the command to launch it — does NOT start the
-     * process. Linux TUN needs both hev and olcRTC running as root under the SAME pkexec
-     * authorization (see DesktopVpnManager.startOlcRtcProcess's combined launch), so the caller
-     * backgrounds this command inside its own privileged process instead of us spawning it directly
-     * under a second, separate pkexec.
+     * process. Used when bundling hev launch with another privileged process (e.g. olcRTC).
      */
     fun prepareHevLaunch(
         hevBinary: Path,
@@ -37,10 +34,65 @@ internal class LinuxTunController(
     }
 
     /**
-     * Polls for the TUN interface + route rule hev's up-script installs. olcRTC's own SOCKS5
-     * readiness check runs first and takes several seconds (WebRTC handshake) — hev, started earlier
-     * in the same combined launch well before olcRTC's exec, has had a comfortable head start by the
-     * time we get here, so this rarely waits long in practice.
+     * Starts hev-socks5-tunnel as an independent privileged process under pkexec/sudo.
+     * Used for non-olcRTC engines (sing-box, xray, amneziawg, etc.) where the proxy core
+     * runs in-process via yptuncore and only hev needs elevation for TUN & route installation.
+     */
+    suspend fun start(
+        hevBinary: Path,
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
+        socksUsername: String = "",
+        socksPassword: String = ""
+    ): Process = withContext(Dispatchers.IO) {
+        val hevCommand = prepareHevLaunch(hevBinary, socksPort, socksUsername, socksPassword)
+        val command = LinuxPrivilege.command(hevCommand)
+        addLog("Starting Linux TUN bridge: ${hevBinary.fileName} -> 127.0.0.1:$socksPort")
+        val process = ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .start()
+        try {
+            awaitReady()
+            process
+        } catch (e: Exception) {
+            runCatching { stop(process) }
+            throw e
+        }
+    }
+
+    /**
+     * Stops the privileged hev process and cleans up routes and DNS settings.
+     */
+    suspend fun stop(process: Process?) {
+        val commands = privilegedCleanupCommands()
+        if (commands.isNotEmpty()) {
+            withContext(Dispatchers.IO) {
+                val script = commands.joinToString("\n")
+                val runtimeDir = DesktopPaths.appDataDir().resolve("runtime")
+                Files.createDirectories(runtimeDir)
+                val scriptFile = Files.createTempFile(runtimeDir, "linux-tun-cleanup-", ".sh")
+                runCatching {
+                    Files.writeString(scriptFile, script)
+                    ProcessBuilder(LinuxPrivilege.command(listOf("sh", scriptFile.toString())))
+                        .redirectErrorStream(true)
+                        .start()
+                        .waitFor(3000, TimeUnit.MILLISECONDS)
+                }.onFailure {
+                    addLog("Failed to clean up Linux TUN routes: ${it.message}")
+                }
+                runCatching { Files.deleteIfExists(scriptFile) }
+            }
+        }
+        if (process != null && process.isAlive) {
+            process.destroy()
+            if (!process.waitFor(1000, TimeUnit.MILLISECONDS)) {
+                process.destroyForcibly()
+            }
+        }
+        onStopped()
+    }
+
+    /**
+     * Polls for the TUN interface + route rule hev's up-script installs.
      */
     suspend fun awaitReady() {
         val deadline = System.currentTimeMillis() + TUN_READY_TIMEOUT_MS
@@ -62,8 +114,7 @@ internal class LinuxTunController(
      * Returns commands only, doesn't invoke pkexec itself — the caller bundles these with olcRTC's
      * own privileged kill into ONE combined pkexec call instead of each of us prompting separately.
      * Best-effort by design (`|| true` throughout): always included, never gates on whether hev is
-     * actually still around, because the caller's pkexec call is happening either way (olcRTC runs
-     * as root in this mode, so an unprivileged kill can never reach it) — bundling this in is free.
+     * actually still around.
      */
     fun privilegedCleanupCommands(): List<String> {
         val commands = mutableListOf<String>()
@@ -254,6 +305,8 @@ internal class LinuxTunController(
                   resolvectl dns $TUN_NAME $MAPDNS_ADDRESS >/dev/null 2>&1 || true
                   resolvectl domain $TUN_NAME '~.' >/dev/null 2>&1 || true
                   resolvectl default-route $TUN_NAME yes >/dev/null 2>&1 || true
+                elif command -v resolvconf >/dev/null 2>&1; then
+                  printf "nameserver %s\n" "$MAPDNS_ADDRESS" | resolvconf -a "$TUN_NAME" 2>/dev/null || true
                 fi
             """.trimIndent()
         }
@@ -266,6 +319,8 @@ internal class LinuxTunController(
                 ip route flush table $ROUTE_TABLE 2>/dev/null || true
                 if command -v resolvectl >/dev/null 2>&1; then
                   resolvectl revert $TUN_NAME >/dev/null 2>&1 || true
+                elif command -v resolvconf >/dev/null 2>&1; then
+                  resolvconf -d "$TUN_NAME" 2>/dev/null || true
                 fi
             """.trimIndent()
         }

--- a/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -371,8 +371,10 @@ class DesktopProxyModeTest {
         assertContains(up, "ip route add default dev olcbox0 table 51820")
         assertContains(up, "ip rule add lookup 51820 pref 20")
         assertContains(up, "resolvectl dns olcbox0 1.1.1.1")
+        assertContains(up, "resolvconf -a \"olcbox0\"")
         assertContains(down, "ip rule del uidrange 0-0 lookup main pref 10")
         assertContains(down, "ip route flush table 51820")
         assertContains(down, "resolvectl revert olcbox0")
+        assertContains(down, "resolvconf -d \"olcbox0\"")
     }
 }

--- a/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/YPtun/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -260,6 +260,72 @@ class DesktopProxyModeTest {
     }
 
     @Test
+    fun linuxGnomeProxyCommandsEnableAndRestoreState() {
+        val enable = LinuxProxyController.enableGnomeProxyCommands("127.0.0.1", 10810)
+        assertEquals(
+            listOf(
+                listOf("gsettings", "set", "org.gnome.system.proxy.http", "host", "127.0.0.1"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.http", "port", "10810"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.https", "host", "127.0.0.1"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.https", "port", "10810"),
+                listOf("gsettings", "set", "org.gnome.system.proxy", "ignore-hosts", "['localhost', '127.0.0.0/8', '::1']"),
+                listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "manual")
+            ),
+            enable
+        )
+
+        val disable = LinuxProxyController.disableGnomeProxyCommands()
+        assertEquals(
+            listOf(listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "none")),
+            disable
+        )
+
+        val state = LinuxGnomeProxyState(
+            mode = "manual",
+            httpHost = "'10.0.0.1'",
+            httpPort = 8080,
+            httpsHost = "'10.0.0.1'",
+            httpsPort = 8080,
+            ignoreHosts = "['localhost']"
+        )
+        val restore = LinuxProxyController.restoreGnomeProxyCommands(state)
+        assertEquals(
+            listOf(
+                listOf("gsettings", "set", "org.gnome.system.proxy.http", "host", "10.0.0.1"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.http", "port", "8080"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.https", "host", "10.0.0.1"),
+                listOf("gsettings", "set", "org.gnome.system.proxy.https", "port", "8080"),
+                listOf("gsettings", "set", "org.gnome.system.proxy", "ignore-hosts", "['localhost']"),
+                listOf("gsettings", "set", "org.gnome.system.proxy", "mode", "manual")
+            ),
+            restore
+        )
+    }
+
+    @Test
+    fun linuxKdeProxyCommandsEnableAndRestoreState() {
+        val enable = LinuxProxyController.enableKdeProxyCommands("http://127.0.0.1:10810", "kwriteconfig5")
+        assertEquals(
+            listOf(
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "1"),
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy", "http://127.0.0.1:10810"),
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy", "http://127.0.0.1:10810")
+            ),
+            enable
+        )
+
+        val disable = LinuxProxyController.disableKdeProxyCommands("kwriteconfig5")
+        assertEquals(
+            listOf(
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "0"),
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpProxy", ""),
+                listOf("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "httpsProxy", "")
+            ),
+            disable
+        )
+    }
+
+    @Test
     fun windowsProxyHttpEnableSetsFixedProxyAndClearsPac() {
         val edits = WindowsProxyController.enableHttpEdits("127.0.0.1:10812")
 


### PR DESCRIPTION
## 🐧 Релиз: Полная поддержка ПК-клиента под Linux (Desktop)

Этот PR закрывает все проблемы и белые пятна клиента под Linux, делая его полноценной и стабильной платформой наряду с Windows и Android.

---

### 🛠️ Что сделано и исправлено:

#### 1. 🚀 Полноценный Linux TUN режим для всех современных протоколов (`LinuxTunController`, `DesktopVpnManager`)
- **Проблема**: Ранее `hev-socks5-tunnel` стартовал только внутри связки с устаревшим `olcRTC` через pkexec-скрипт. При выборе любого сервера на современных ядрах (`sing-box`, `Xray`, `AmneziaWG`, `OpenFlux`, `MasterDNS`, `VK-TURN`) процесс туннеля вообще не создавался, и клиент зависал по таймауту `olcbox0 routes were not installed`.
- **Решение**: Реализован автономный запуск и корректное завершение `hev-socks5-tunnel` как отдельного привилегированного процесса под `pkexec` / `sudo` для всех in-process движков (`yptuncore`).
- **Очистка**: Реализован надёжный teardown маршрутов (таблица `51820`, правила `ip rule`) и интерфейса `olcbox0` при дисконнекте.
- **DNS Fallback**: Добавлен fallback на `resolvconf` в `upScriptContent` / `downScriptContent` для Linux-дистрибутивов без `systemd-resolved` (Debian, Arch, Alpine, Void).

#### 2. 🌐 Поддержка режима «Системный прокси» (`LinuxProxyController`)
- **Проблема**: На Linux переключение в режим «Прокси» падало с ошибкой `UnsupportedProxyController: System proxy mode supports macOS and Windows`.
- **Решение**: Реализован полноценный `LinuxProxyController`:
  - **GNOME / Cinnamon / MATE / Budgie**: управление через `gsettings` (`org.gnome.system.proxy`).
  - **KDE Plasma**: управление через `kwriteconfig5` / `kwriteconfig6` (`kioslaverc`).
  - **Восстановление**: корректное сохранение и восстановление пользовательских настроек при отключении (`restore()`).
  - **Самовосстановление**: метод `clearStaleProxy()` для сброса зависшего прокси при краше приложения.

#### 3. 🔗 Поддержка Deep Links и ассоциаций MIME-типов
- В `.desktop` файл AppImage и системы добавлены ассоциации для протоколов: `x-scheme-handler/yptun`, `vless`, `vmess`, `ss`, `trojan`, `hysteria2`, `tuic`.
- В `DesktopSingleInstance` реализована передача CLI-аргументов между процессами: при клике на ссылку в браузере запущенное приложение перехватывает ссылку, импортирует сервер и поднимает окно на передний план.

#### 4. 📦 Обновление версионирования
- Поднят `versionCode` до **356** в `gradle.properties`.
- Добавлены unit-тесты в `DesktopProxyModeTest.kt` для генерации команд GNOME, KDE и скриптов маршрутизации.

---

### 🧪 Тестирование:
- [x] Unit-тесты `DesktopProxyModeTest` (`linuxGnomeProxyCommandsEnableAndRestoreState`, `linuxKdeProxyCommandsEnableAndRestoreState`, `linuxTunScriptsRouteUserTrafficThroughTunAndKeepRootDirect`).
- [x] Совместимость с Conventional Commits.
