### PR TITLE
feat(ios): подготовка клиента к TestFlight и устранение причин реджекта

### DIFF
--- a/YPtun/iosApp/iosApp/Info.plist
+++ b/YPtun/iosApp/iosApp/Info.plist
@@ -28,6 +28,36 @@
 	<string>Фотографии нужны для сканирования QR-кодов с конфигурациями из медиатеки.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>org.yptun.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>yptun</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.yptun.control.start</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Подключить VPN</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>bolt.fill</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.yptun.control.stop</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Отключить VPN</string>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>bolt.slash.fill</string>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/YPtun/iosApp/iosApp/Info.plist
+++ b/YPtun/iosApp/iosApp/Info.plist
@@ -24,6 +24,10 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Камера нужна, чтобы сканировать QR-коды с конфигурациями.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Фотографии нужны для сканирования QR-кодов с конфигурациями из медиатеки.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/YPtun/iosApp/iosApp/OlcboxIosApp.swift
+++ b/YPtun/iosApp/iosApp/OlcboxIosApp.swift
@@ -1,10 +1,36 @@
 import NetworkExtension
 import SharedUI
 import SwiftUI
+import UIKit
 import WidgetKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    static var onShortcut: ((UIApplicationShortcutItem) -> Void)?
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        if let shortcutItem = options.shortcutItem {
+            Self.onShortcut?(shortcutItem)
+        }
+        return UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+    }
+
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        Self.onShortcut?(shortcutItem)
+        completionHandler(true)
+    }
+}
 
 @main
 struct OlcboxIosApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private let platformBridge: SwiftPlatformBridge
     private let coreBridge: SwiftCoreBridge
     private let appSession: IosAppSession
@@ -19,12 +45,19 @@ struct OlcboxIosApp: App {
         }
         let platformBridge = SwiftPlatformBridge()
         let coreBridge = SwiftCoreBridge()
-        self.platformBridge = platformBridge
-        self.coreBridge = coreBridge
-        self.appSession = IosAppFactory().createSession(
+        let session = IosAppFactory().createSession(
             platformBridge: platformBridge,
             coreBridge: coreBridge
         )
+        self.platformBridge = platformBridge
+        self.coreBridge = coreBridge
+        self.appSession = session
+
+        AppDelegate.onShortcut = { item in
+            DispatchQueue.main.async {
+                Self.handleShortcut(item, session: session)
+            }
+        }
     }
 
     var body: some Scene {
@@ -34,6 +67,37 @@ struct OlcboxIosApp: App {
                 appSession: appSession
             )
             .ignoresSafeArea()
+            .onOpenURL { url in
+                handleUrl(url)
+            }
+        }
+    }
+
+    private static func handleShortcut(_ item: UIApplicationShortcutItem, session: IosAppSession) {
+        switch item.type {
+        case "org.yptun.control.start":
+            session.startVpn()
+        case "org.yptun.control.stop":
+            session.stopVpn()
+        default:
+            break
+        }
+    }
+
+    private func handleUrl(_ url: URL) {
+        guard url.scheme?.lowercased() == "yptun" else { return }
+        if url.host == "control" {
+            let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            if path == "start" {
+                appSession.startVpn()
+            } else if path == "stop" {
+                appSession.stopVpn()
+            } else if path == "restart" {
+                appSession.stopVpn()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.appSession.startVpn()
+                }
+            }
         }
     }
 }

--- a/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreen.kt
+++ b/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreen.kt
@@ -156,6 +156,13 @@ fun HomeScreen(
     val state by viewModel.state.collectAsState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.startBlockedReason) {
+        val reason = state.startBlockedReason
+        if (!reason.isNullOrBlank()) {
+            snackbarHostState.showSnackbar(reason)
+        }
+    }
     // True while an "Auto = fastest" pass (ping → pick → connect) is in flight, so the Auto button
     // shows a spinner and ignores re-taps instead of launching a second concurrent pass.
     var autoRunning by remember { mutableStateOf(false) }

--- a/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
+++ b/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
@@ -68,7 +68,11 @@ class HomeScreenViewModel(
                         VpnStatus.Reconnecting -> it.copy(isVpnConnected = true, isVpnLoading = true)
                         VpnStatus.Stopping -> it.copy(isVpnConnected = false, isVpnLoading = false)
                         VpnStatus.Disconnected -> it.copy(isVpnConnected = false, isVpnLoading = false)
-                        is VpnStatus.Error -> it.copy(isVpnConnected = false, isVpnLoading = false)
+                        is VpnStatus.Error -> it.copy(
+                            isVpnConnected = false,
+                            isVpnLoading = false,
+                            startBlockedReason = status.message
+                        )
                     }
                 }
             }
@@ -151,7 +155,7 @@ class HomeScreenViewModel(
         }
 
         viewModelScope.launch {
-            _state.update { it.copy(isVpnLoading = true) }
+            _state.update { it.copy(isVpnLoading = true, startBlockedReason = null) }
             try {
                 if (_state.value.isVpnConnected || vpnManager.status.value is VpnStatus.Connected) {
                     vpnManager.stopVpn()

--- a/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationSettingsScreen.kt
+++ b/YPtun/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationSettingsScreen.kt
@@ -689,24 +689,36 @@ private fun EngineSelector(
     enabled: Boolean,
     onSelected: (EngineType) -> Unit
 ) {
-    val options = listOf(
-        EngineType.Stealth,
-        EngineType.Standard,
-        EngineType.Chain,
-        EngineType.VkTurn,
-        EngineType.MasterDns,
-        EngineType.OpenFlux
-    )
+    val isIos = remember { org.olcbox.app.data.identity.DeviceInfo.os.equals("iOS", ignoreCase = true) }
+    val options = remember(isIos) {
+        if (isIos) {
+            listOf(
+                EngineType.Stealth,
+                EngineType.Standard,
+                EngineType.Chain,
+                EngineType.VkTurn,
+                EngineType.MasterDns
+            )
+        } else {
+            listOf(
+                EngineType.Stealth,
+                EngineType.Standard,
+                EngineType.Chain,
+                EngineType.VkTurn,
+                EngineType.MasterDns,
+                EngineType.OpenFlux
+            )
+        }
+    }
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         SectionTitle(title = LocalStrings.current.engineSection, subtitle = engineSubtitle(selected))
 
-        // ONE cohesive 2×2 block: a single rounded outline drawn ONCE around all four engines, with thin
-        // inner dividers between the cells — no per-row pills, no offset hack, no seam/gap. Two rows of
-        // two equal-width cells; the row height tracks the tallest cell (IntrinsicSize.Min) so the
-        // vertical divider spans it. clip() rounds the selected-cell highlight to the block's corners.
+        // ONE cohesive block: a single rounded outline drawn ONCE around all engines, with thin
+        // inner dividers between the cells. Two equal-width cells per row; the row height tracks the
+        // tallest cell (IntrinsicSize.Min) so the vertical divider spans it.
         val shape = RoundedCornerShape(20.dp)
         val outline = MaterialTheme.colorScheme.outline
         Column(
@@ -731,6 +743,10 @@ private fun EngineSelector(
                             onClick = { onSelected(engine) },
                             modifier = Modifier.weight(1f)
                         )
+                    }
+                    if (rowOptions.size == 1) {
+                        VerticalDivider(color = outline)
+                        Spacer(modifier = Modifier.weight(1f))
                     }
                 }
             }

--- a/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/MainViewController.kt
+++ b/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/MainViewController.kt
@@ -67,6 +67,14 @@ class IosAppSession internal constructor(
         IosPlatformHooks.core = coreBridge
     }
 
+    fun startVpn() {
+        dependencies.vpnManager.startVpn()
+    }
+
+    fun stopVpn() {
+        dependencies.vpnManager.stopVpn()
+    }
+
     fun createViewController(): UIViewController {
         return ComposeUIViewController {
             IosApp(platformBridge, dependencies)

--- a/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
+++ b/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
@@ -50,6 +50,14 @@ import platform.NetworkExtension.NEVPNStatusDidChangeNotification
 import platform.NetworkExtension.NEVPNStatusDisconnecting
 import platform.NetworkExtension.NEVPNStatusReasserting
 import platform.UIKit.UIApplication
+import platform.UIKit.UIImpactFeedbackGenerator
+import platform.UIKit.UIImpactFeedbackStyle
+import platform.UIKit.UIImpactFeedbackStyleLight
+import platform.UIKit.UIImpactFeedbackStyleMedium
+import platform.UIKit.UINotificationFeedbackGenerator
+import platform.UIKit.UINotificationFeedbackType
+import platform.UIKit.UINotificationFeedbackTypeError
+import platform.UIKit.UINotificationFeedbackTypeSuccess
 import kotlin.coroutines.resume
 
 /**
@@ -103,9 +111,26 @@ class IosVpnManager(
         }
     }
 
+    private fun triggerImpactHaptic(style: UIImpactFeedbackStyle) {
+        runCatching {
+            val generator = UIImpactFeedbackGenerator(style)
+            generator.prepare()
+            generator.impactOccurred()
+        }
+    }
+
+    private fun triggerNotificationHaptic(type: UINotificationFeedbackType) {
+        runCatching {
+            val generator = UINotificationFeedbackGenerator()
+            generator.prepare()
+            generator.notificationOccurred(type)
+        }
+    }
+
     override fun needsPermission(): Boolean = false
 
     override fun startVpn() {
+        triggerImpactHaptic(UIImpactFeedbackStyleMedium)
         scope.launch {
             val active = locationsRepository.getActiveLocation()?.location?.normalized()
             if (active == null || !active.isComplete()) {
@@ -146,6 +171,7 @@ class IosVpnManager(
     }
 
     override fun stopVpn() {
+        triggerImpactHaptic(UIImpactFeedbackStyleLight)
         scope.launch {
             setStatus(VpnStatus.Stopping)
             manager?.connection?.stopVPNTunnel() ?: setStatus(VpnStatus.Disconnected)
@@ -301,13 +327,19 @@ class IosVpnManager(
                 _connectedSince.value = m.connection.connectedDate
                     ?.let { (it.timeIntervalSince1970 * 1000).toLong() } ?: 0L
                 setStatus(VpnStatus.Connected)
+                triggerNotificationHaptic(UINotificationFeedbackTypeSuccess)
             }
             NEVPNStatusReasserting -> setStatus(VpnStatus.Reconnecting)
             NEVPNStatusDisconnecting -> setStatus(VpnStatus.Stopping)
             else -> {
                 _connectedSince.value = 0L
                 val failure = IosSharedStore.readText(IosTunnelSession.ERROR_FILE)?.trim().orEmpty()
-                setStatus(if (wasConnecting && failure.isNotEmpty()) VpnStatus.Error(failure) else VpnStatus.Disconnected)
+                if (wasConnecting && failure.isNotEmpty()) {
+                    setStatus(VpnStatus.Error(failure))
+                    triggerNotificationHaptic(UINotificationFeedbackTypeError)
+                } else {
+                    setStatus(VpnStatus.Disconnected)
+                }
                 wasConnecting = false
             }
         }

--- a/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
+++ b/YPtun/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
@@ -253,8 +253,12 @@ class IosVpnManager(
         }
         val m = existing ?: if (createIfMissing) NETunnelProviderManager() else return null
         if (existing == null || !m.enabled) {
+            val tunnelId = platform.Foundation.NSBundle.mainBundle.bundleIdentifier
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "$it.tunnel" }
+                ?: TUNNEL_BUNDLE_ID
             m.setProtocolConfiguration(NETunnelProviderProtocol().apply {
-                setProviderBundleIdentifier(TUNNEL_BUNDLE_ID)
+                setProviderBundleIdentifier(tunnelId)
                 setServerAddress("YPtun")
             })
             m.setLocalizedDescription("YPtun")


### PR DESCRIPTION
## Что делает этот PR?
Комплекс изменений для подготовки iOS-клиента к тестированию в TestFlight и модерации Apple App Store:

1. **fix(ios)**: добавлен NSPhotoLibraryUsageDescription в Info.plist (требуется iOS при выборе QR-кода из медиатеки, предотвращает сбои и реджект Apple).
2. **fix(ios)**: добавлен ключ ITSAppUsesNonExemptEncryption = NO для устранения ручной верификации экспортного шифрования при каждой сборке в TestFlight.
3. **fix(ios)**: убрана жесткая привязка к bundle ID org.olcbox.app.tunnel — идентификатор туннеля теперь определяется динамически как ${NSBundle.mainBundle.bundleIdentifier}.tunnel, что обеспечивает работу с любым App ID (org.yptun.app).
4. **feat(ui)**: скрыт неподдерживаемый протокол OpenFlux в выборе движка на iOS (LocationSettingsScreen).
5. **feat(ui)**: ошибки старта туннеля (VpnStatus.Error) теперь перехватываются во ViewModel и показываются пользователю в виде всплывающего уведомления (Snackbar).
6. **feat(ios)**: добавлены нативные **Quick Actions** (UIApplicationShortcutItems в Info.plist — «Подключить VPN» и «Отключить VPN» при зажатии иконки на рабочем столе), поддержка deep links yptun://control/* в SwiftUI, а также **Taptic Feedback** (UIImpactFeedbackGenerator / UINotificationFeedbackGenerator) при старте/стопе и смене статуса туннеля.

## Связанный issue
Подготовка к первому релизу в TestFlight / App Store.

## Тип изменения
- [x] 🐛 Исправление бага
- [x] ✨ Новая фича
- [ ] 🌐 Перевод / локализация
- [ ] 🧹 Рефакторинг / чистка
- [ ] 📖 Документация

## Чеклист
- [x] Ответвление от Beta
- [x] Проходят тесты
- [x] Изменение сфокусировано на iOS-готовности и разбито на атомарные коммиты

## Как тестировал
- Запущен CI-пайплайн на macOS (.github/workflows/ios.yml) для сборки XCFramework и Xcode проекта.